### PR TITLE
Fix: lunacy embracer missing athletics

### DIFF
--- a/modular_twilight_axis/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/modular_twilight_axis/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -36,6 +36,7 @@
 	H.adjust_skillrank(/datum/skill/craft/alchemy, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/labor/fishing, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, SKILL_LEVEL_JOURNEYMAN, TRUE)
 
 	H.change_stat("strength", 3)
 	H.change_stat("willpower", 2)


### PR DESCRIPTION
Исправляет проблему подкласса вретча-лунатика: отсутствие какой-либо атлетики. Пока добавил третий уровень, посмотрим, как покажет на деле. 