### PR TITLE
feature: old rice hat toggle ears on MMB

### DIFF
--- a/modular_twilight_axis/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/modular_twilight_axis/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -13,6 +13,12 @@
 	mob_overlay_icon = 'modular_twilight_axis/icons/roguetown/clothing/onmob/head.dmi'
 	icon_state = "eaststrawhat"
 	flags_inv = HIDEEARS
+	var/hides_ears = TRUE
+
+/obj/item/clothing/head/roguetown/eaststrawhat/MiddleClick(mob/user, params)
+	. = ..()
+	hides_ears = !hides_ears
+	flags_inv = hides_ears ? HIDEEARS : null
 
 /obj/item/clothing/head/roguetown/grenzelhofthat/decorated
 	armor = null


### PR DESCRIPTION
На среднюю кнопку мыши переключаются флаги невидимости у `worn rice hat`. 

Учитывайте, что после смены флага кукле стоит покрутиться или каким-либо другим образом обновить на себе спрайты.

Сделано по реквесту