### PR TITLE
Saiga is no longer a boat

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -20,6 +20,10 @@
 
 	var/del_on_unbuckle_all = FALSE
 
+/datum/component/riding/no_ocean/Initialize()//no copy paste
+	. = ..()
+	forbid_turf_typecache = typecacheof(/turf/open/water/ocean/deep)
+
 /datum/component/riding/Initialize()
 	if(!ismovableatom(parent))
 		return COMPONENT_INCOMPATIBLE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -59,8 +59,8 @@
 		points += "!"
 	visible_message(span_danger("[src] falls down[points]"), \
 					span_danger("I fall down[points]"))
-	playsound(src.loc, 'sound/foley/zfall.ogg', 100, FALSE)
 	if(!isgroundlessturf(T))
+		playsound(src.loc, 'sound/foley/zfall.ogg', 100, FALSE)
 		ZImpactDamage(T, levels)
 		record_round_statistic(STATS_MOAT_FALLERS)
 	return ..()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -139,7 +139,7 @@
 	. = ..()
 	can_buckle = TRUE
 	buckle_lying = FALSE
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 8), TEXT_SOUTH = list(0, 8), TEXT_EAST = list(-2, 8), TEXT_WEST = list(2, 8)))
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)

--- a/code/modules/mob/living/simple_animal/rogue/farm/goat.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/goat.dm
@@ -19,7 +19,7 @@
 	..()
 	deaggroprob = 50
 	if(can_buckle)
-		var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+		var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
 		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(-2, 6), TEXT_WEST = list(2, 6)))
 		D.set_vehicle_dir_layer(SOUTH, MOB_LAYER+0.1)
 		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
@@ -268,7 +268,7 @@
 	..()
 	deaggroprob = 20
 	if(can_buckle)
-		var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+		var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
 		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(-2, 6), TEXT_WEST = list(2, 6)))
 		D.set_vehicle_dir_layer(SOUTH, MOB_LAYER+0.1)
 		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)

--- a/code/modules/mob/living/simple_animal/rogue/farm/hog.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/hog.dm
@@ -240,7 +240,7 @@
 	..()
 	deaggroprob = 50
 	if(can_buckle)
-		var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+		var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
 		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(-2, 6), TEXT_WEST = list(2, 6)))
 		D.set_vehicle_dir_layer(SOUTH, MOB_LAYER+0.1)
 		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)

--- a/code/modules/mob/living/simple_animal/rogue/game/drider.dm
+++ b/code/modules/mob/living/simple_animal/rogue/game/drider.dm
@@ -59,7 +59,7 @@
 	..()
 	deaggroprob = 20
 	if(can_buckle)
-		var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+		var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
 		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 9), TEXT_SOUTH = list(0, 9), TEXT_EAST = list(-1, 9), TEXT_WEST = list(-1, 9)))
 		D.set_vehicle_dir_layer(NORTH, MOB_LAYER+0.5)
 		D.set_vehicle_dir_layer(SOUTH, OBJ_LAYER)

--- a/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
+++ b/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
@@ -199,7 +199,7 @@
 	..()
 	deaggroprob = 30
 	if(can_buckle)
-		var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+		var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
 		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 8), TEXT_SOUTH = list(0, 8), TEXT_EAST = list(-2, 8), TEXT_WEST = list(2, 8)))
 		D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -812,7 +812,7 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 /mob/living/simple_animal/hostile/user_buckle_mob(mob/living/M, mob/user)
 	if(user != M)
 		return
-	var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding)
+	var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding/no_ocean)
 	if(riding_datum)
 		var/time2mount = 12
 		riding_datum.vehicle_move_delay = move_to_delay
@@ -844,7 +844,7 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 	if (stat == DEAD)
 		return
 	var/oldloc = loc
-	var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding)
+	var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding/no_ocean)
 	if(tame && riding_datum)
 		if(riding_datum.handle_ride(user, direction))
 			riding_datum.vehicle_move_delay = move_to_delay


### PR DESCRIPTION
## About The Pull Request

Saiga can no longer navigate the sea as a motorboat.
Port from:  https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1173

## Testing Evidence

<img width="432" height="37" alt="image" src="https://github.com/user-attachments/assets/c9d73405-4c23-45de-8d38-18889042cae5" />

## Why It's Good For The Game

There will be no more knights cutting through the sea on saigas, as if they were the marine police.

