### PR TITLE
[Modular] Sea Rogue buff

### DIFF
--- a/modular_twilight_axis/firearms/code/jobs/corsair.dm
+++ b/modular_twilight_axis/firearms/code/jobs/corsair.dm
@@ -84,6 +84,7 @@
 			H.set_blindness(0)
 			mask = /obj/item/clothing/mask/rogue/facemask/steel/kazengun
 			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
+			armor = /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
 			cloak = /obj/item/clothing/cloak/eastcloak1
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			head = /obj/item/clothing/head/roguetown/mentorhat


### PR DESCRIPTION
## About The Pull Request

- Добавил две бутыль бомбы каперу и два смока Вокоу.

- Добавил Вокоу броню на грудь со статами studded кожанки
## Testing Evidence



## Why It's Good For The Game

- Наплакали, что не хватает брони и что вретч раундстарт должен быть готов к бою и что взамен джорнимэна ближки ему надо чет дать. Ну я и дал по две бомбы. Смоки, кстати, не крафтятся.

- Йоу ещё больше дрипа

## Changelog

:cl:
add: 2 бомбы каперу и вокоу.
add: защиту на грудь вокоу
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
