### PR TITLE
Runtimes fix 2

### DIFF
--- a/code/controllers/subsystem/rivers.dm
+++ b/code/controllers/subsystem/rivers.dm
@@ -22,11 +22,13 @@ SUBSYSTEM_DEF(rivers)
 		if(!istype(thing, /turf/open/water/river))
 			processing -= thing
 			continue
-		if(!QDELETED(thing))
-			thing.process_river()
+		var/turf/open/water/river/river = thing
+		if(!QDELETED(river))
+			river.process_river()
 		else
-			processing -= thing
-		if (MC_TICK_CHECK)
+			processing -= river
+
+		if(MC_TICK_CHECK)
 			return
 
 /datum/controller/subsystem/rivers/Recover()


### PR DESCRIPTION
## About The Pull Request

Non-river turfs could remain in SSrivers.processing after ChangeTurf() or subsystem recovery, causing process_river() to be called on invalid types.

## Testing Evidence

Не могу потестить

## Why It's Good For The Game

Фиксит рантайм

## Changelog
Added type filtering in SSrivers.fire() and ensured river turfs unregister on Destroy().

:cl:
fix: fixed a few things
code: changed some code
/:cl:

