### PR TITLE
Ported CheckToolReach implementation from Vanderling.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -505,35 +505,30 @@ GLOBAL_LIST_EMPTY(reach_dummy_pool)
 	if(!here || !there)
 		return FALSE
 
+	var/turf/start = get_turf(here)
+	if(!start)
+		return FALSE
+
 	switch(reach)
 		if(0)
 			return FALSE
 		if(1)
-			return FALSE // here.Adjacent(there)
-
+			return FALSE
 		if(2 to INFINITY)
-			var/turf/start = get_turf(here)
-			if(!start)
-				return FALSE
-
-			var/obj/dummy = new(start)
+			var/obj/effect/dummy = new(start)
 			dummy.pass_flags |= PASSTABLE
 			dummy.movement_type = FLYING
 			dummy.invisibility = INVISIBILITY_ABSTRACT
-
 			for(var/i in 1 to reach)
 				if(dummy.CanReach(there))
 					qdel(dummy)
 					return TRUE
-
 				var/turf/T = get_step(dummy, get_dir(dummy, there))
 				if(!T || !dummy.Move(T))
 					qdel(dummy)
 					return FALSE
-
 			qdel(dummy)
 			return FALSE
-
 
 
 // Default behavior: ignore double clicks (the second click that makes the doubleclick call already calls for a normal click)


### PR DESCRIPTION
## About The Pull Request
Улучшенная версия /proc/CheckToolReach(atom/movable/here, atom/movable/there, reach)
Устойчивее к нулям и более быструю работу за счет var/obj/effect/dummy = new(start) вместо var/obj/dummy = new(start)

Next chapter of forcemove() fix
https://github.com/Azure-Peak/Azure-Peak/pull/5485

## Testing Evidence

Testing...

## Why It's Good For The Game

Why this is good:
- Eliminates forceMove calls on objects with loc = null
- Removes an entire class of runtime errors ("No valid destination passed into forceMove")
- Avoids unsafe reuse of pooled dummy objects with undefined state
- Reduces side effects by not touching forceMove at all
- Logic is simpler, deterministic, and matches a proven upstream implementation

## Changelog

:cl:
qol: made something easier to use
fix: fixed a few things
code: changed some code
refactor: refactored some code
/:cl:
