### PR TITLE
New Ring "Event_Ring". Custom stats, traits, chat message when equipped

### DIFF
--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -551,6 +551,8 @@
 	)
 	// Example default traits: admins can edit/remove these via VV
 	var/list/traits = list(TRAIT_NOBLE)
+	// Customizable message shown when ring is equipped; editable via VV
+	var/equip_message = "You feel the ring's power settle upon you."
 	var/active_item = FALSE
 
 // Procs are defined as top-level paths so they run in the correct scope
@@ -568,7 +570,8 @@
 		if(traits && traits.len)
 			for(var/t in traits)
 				ADD_TRAIT(user, t, TRAIT_GENERIC)
-		to_chat(user, span_green("You feel the ring's power settle upon you."))
+		if(equip_message)
+			to_chat(user, span_green(equip_message))
 	return
 
 


### PR DESCRIPTION
## About The Pull Request
Добавлен новый предмет: Event Ring
Кольцо имеет три основные переменные, редактируемые через View Variables (VV):
stat_mods: список модификаторов характеристик, которые получает носитель.
traits: список трейтов, которые даются персонажу.
equip_message: позволяет поменять надпись в чате при надевании (есть возможность использовать вместе с кодом
("<.font size="5" color="ADFF2F".>ENDURE!<./font.>)"
Также вы сами можете поменять название предмета и его описание, а также icon для конкретной ситуации.

## Testing Evidence
Проверил на локалке. Добавил, чтобы сразу были примеры, дабы ивентер не думал, как ему добавлять туда статы. В общем, просто меняете циферки и все. Трейты добавлять придется ручками.

## Why It's Good For The Game
Дает ивентерам инструмент-«пустышку», который можно превратить в любой кастомный артефакт без необходимости просить кодеров добавлять новый предмет в файлы игры.
Вместо создания десятков уникальных колец для разных ситуаций, админы могут использовать один объект и настраивать его под конкретный сценарий.

## Changelog
:cl: admin: Добавлено ивентовое кольцо (Event_Ring), характеристики и трейты которого можно настраивать через View Variables. /:cl: