### PR TITLE
Реверт реверта ПРа на перевод заклинаний в таймер

### DIFF
--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -36,8 +36,8 @@
 		active = TRUE
 		add_ranged_ability(user, null, TRUE)
 		on_activation(user)
+	
 	update_icon()
-	start_recharge()
 
 /obj/effect/proc_holder/spell/invoked/deactivate(mob/living/user) //Deactivates the currently active spell (icon click)
 	..()

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -125,17 +125,15 @@
 	/// Amount of PQ gained for reviving people
 	var/revive_pq = PQ_GAIN_REVIVE
 
-/obj/effect/proc_holder/spell/invoked/revive/start_recharge()
-	var/old_recharge = recharge_time
-	// Because the cooldown for anastasis is so incredibly low, not having tech impacts them more heavily than other faiths
+/obj/effect/proc_holder/spell/invoked/revive/calculate_recharge_time()
+	var/final_time = ..() 
+	
 	var/tech_resurrection_modifier = SSchimeric_tech.get_resurrection_multiplier()
+	
 	if(tech_resurrection_modifier > 1)
-		recharge_time = initial(recharge_time) * (tech_resurrection_modifier * 1.25)
-	else
-		recharge_time = initial(recharge_time)
-	if(charge_counter >= old_recharge && old_recharge > 0)
-		charge_counter = recharge_time
-	. = ..()
+		final_time *= (tech_resurrection_modifier * 1.25)
+	
+	return max(cooldown_min, round(final_time))
 
 /obj/effect/proc_holder/spell/invoked/revive/cast(list/targets, mob/living/user)
 	..()

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -376,19 +376,14 @@
 	to_chat(user, span_notice("You bless [target] with Eora's love!"))
 	return TRUE
 
-/obj/effect/proc_holder/spell/invoked/bless_food/start_recharge()
-	if(ranged_ability_user)
-		var/holy_skill = ranged_ability_user.get_skill_level(associated_skill)
-		// Reduce recharge by 6 seconds per skill level
-		var/skill_reduction = (6 SECONDS) * holy_skill
-		recharge_time = base_recharge_time - skill_reduction
-		// Ensure recharge doesn't go below 0
-		if(recharge_time < 0)
-			recharge_time = 0
-	else
-		recharge_time = base_recharge_time
-
-	START_PROCESSING(SSfastprocess, src)
+/obj/effect/proc_holder/spell/invoked/bless_food/calculate_recharge_time()
+	if(!ranged_ability_user)
+		return base_recharge_time
+		
+	var/holy_skill = ranged_ability_user.get_skill_level(associated_skill)
+	var/skill_reduction = (6 SECONDS) * holy_skill
+	
+	return max(cooldown_min, base_recharge_time - skill_reduction)
 
 /obj/effect/proc_holder/spell/invoked/pomegranate
 	name = "Amaranth Sanctuary"

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -198,21 +198,35 @@ Somewhat fitting, considering the broadness of their domains. I also just think 
 	associated_skill = /datum/skill/magic/holy
 
 /obj/effect/proc_holder/spell/invoked/invisibility/cast(list/targets, mob/living/user)
-	if(isliving(targets[1]))
-		var/mob/living/target = targets[1]
-		if(target.anti_magic_check(TRUE, TRUE))
-			return FALSE
-		target.visible_message(span_warning("[target] starts to fade into thin air!"), span_notice("You start to become invisible!"))
-		var/dur = max((5 * (user.get_skill_level(associated_skill))), 5)
-		if(dur >= recharge_time)
-			recharge_time = dur + 5 SECONDS
-		animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
-		target.mob_timers[MT_INVISIBILITY] = world.time + dur SECONDS
-		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), dur SECONDS)
-		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), dur SECONDS)
-		return TRUE
-	revert_cast()
-	return FALSE
+	if(!isliving(targets[1]))
+		revert_cast()
+		return FALSE
+
+	var/mob/living/target = targets[1]
+	if(target.anti_magic_check(TRUE, TRUE))
+		return FALSE
+
+	target.visible_message(span_warning("[target] starts to fade into thin air!"), span_notice("You start to become invisible!"))
+	var/dur = max((5 * (user.get_skill_level(associated_skill))), 5)
+	animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
+	target.mob_timers[MT_INVISIBILITY] = world.time + dur SECONDS
+
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), dur SECONDS)
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), dur SECONDS)
+
+	return TRUE
+
+/obj/effect/proc_holder/spell/invoked/invisibility/calculate_recharge_time()
+    var/final_time = ..() 
+    
+    if(ranged_ability_user)
+        var/skill_level = ranged_ability_user.get_skill_level(associated_skill)
+        var/dur = max((5 * skill_level), 5) SECONDS
+        
+        if(dur >= final_time)
+            final_time = dur + 5 SECONDS
+            
+    return max(cooldown_min, final_time)
 
 /obj/effect/proc_holder/spell/self/noc_spell_bundle
 	name = "Arcyne Affinity"

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -26,13 +26,12 @@
 	var/harms_undead = TRUE
 	priest_excluded = TRUE
 
-/obj/effect/proc_holder/spell/invoked/resurrect/start_recharge()
-	var/old_recharge = recharge_time
-	recharge_time = initial(recharge_time) * SSchimeric_tech.get_resurrection_multiplier()
-	// If the spell was fully charged, keep it fully charged after adjusting recharge_time
-	if(charge_counter >= old_recharge && old_recharge > 0)
-		charge_counter = recharge_time
-	. = ..()
+/obj/effect/proc_holder/spell/invoked/resurrect/calculate_recharge_time()
+	var/final_time = ..()
+	
+	final_time *= SSchimeric_tech.get_resurrection_multiplier()
+	
+	return max(cooldown_min, round(final_time))
 
 /obj/effect/proc_holder/spell/invoked/resurrect/proc/get_current_required_items()
 	if(SSchimeric_tech.has_revival_cost_reduction() && length(alt_required_items))

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -203,6 +203,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/miracle = FALSE
 	var/devotion_cost = 0
 	var/ignore_cockblock = FALSE //whether or not to ignore TRAIT_SPELLCOCKBLOCK
+	var/next_recharge_time = 0
 
 	action_icon_state = "spell0"
 	action_icon = 'icons/mob/actions/roguespells.dmi'
@@ -362,7 +363,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		return TRUE
 	switch(charge_type)
 		if("recharge")
-			if(charge_counter < recharge_time)
+			if(world.time < next_recharge_time)
 				to_chat(user, still_recharging_msg)
 				return FALSE
 		if("charges")
@@ -398,13 +399,12 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 /obj/effect/proc_holder/spell/Initialize()
 	. = ..()
-	START_PROCESSING(SSfastprocess, src)
 
 	still_recharging_msg = span_warning("[name] is still recharging!")
 	charge_counter = recharge_time
+	next_recharge_time = world.time
 
 /obj/effect/proc_holder/spell/Destroy()
-	STOP_PROCESSING(SSfastprocess, src)
 	qdel(action)
 	return ..()
 
@@ -421,24 +421,30 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/proc/can_target(mob/living/target)
 	return TRUE
 
+/obj/effect/proc_holder/spell/proc/calculate_recharge_time()
+	var/final_time = initial(recharge_time)
+	var/mob/living/user = ranged_ability_user || action?.owner
+
+	if(user && !is_cdr_exempt)
+		var/stain_diff = user.STAINT - SPELL_SCALING_THRESHOLD
+		if(stain_diff > 0)
+			stain_diff = min(stain_diff, SPELL_POSITIVE_SCALING_THRESHOLD - SPELL_SCALING_THRESHOLD)
+		
+		final_time -= initial(recharge_time) * stain_diff * COOLDOWN_REDUCTION_PER_INT
+
+	return max(cooldown_min, round(final_time))
+
 /obj/effect/proc_holder/spell/proc/start_recharge()
-	if(ranged_ability_user && !is_cdr_exempt)
-		if(ranged_ability_user.STAINT > SPELL_SCALING_THRESHOLD)
-			var/diff = min(ranged_ability_user.STAINT, SPELL_POSITIVE_SCALING_THRESHOLD) - SPELL_SCALING_THRESHOLD
-			recharge_time = initial(recharge_time) - (initial(recharge_time) * diff * COOLDOWN_REDUCTION_PER_INT)
-		else if(ranged_ability_user.STAINT < SPELL_SCALING_THRESHOLD)
-			var/diff2 = SPELL_SCALING_THRESHOLD - ranged_ability_user.STAINT
-			recharge_time = initial(recharge_time) + (initial(recharge_time) * (diff2 * COOLDOWN_REDUCTION_PER_INT))
+    var/final_time = calculate_recharge_time()
+    
+    next_recharge_time = world.time + final_time
+    addtimer(CALLBACK(src, .proc/finish_recharge), final_time)
 
-	START_PROCESSING(SSfastprocess, src)
+/obj/effect/proc_holder/spell/proc/finish_recharge()
+	charge_counter = recharge_time
 
-/obj/effect/proc_holder/spell/process()
-	if(charge_counter <= recharge_time) // Edge case when charge counter is set
-		charge_counter += 2	//processes 5 times per second instead of 10.
-		if(charge_counter >= recharge_time)
-			action.UpdateButtonIcon()
-			charge_counter = recharge_time
-			STOP_PROCESSING(SSfastprocess, src)
+	if(action)
+		action.UpdateButtonIcon()
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = TRUE, mob/user = usr) //if recharge is started is important for the trigger spells
 	if(!ignore_los)
@@ -557,6 +563,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	start_recharge()
 	switch(charge_type)
 		if("recharge")
+			next_recharge_time = world.time
 			charge_counter = recharge_time
 		if("charges")
 			charge_counter++


### PR DESCRIPTION
## About The Pull Request

Мне не совсем понятно зачем оффы это ревертнули и теперь все жалуются, что заклинания опять по уебански работают. Мужик на оффах обещал, что найдет решение лучше, но зачем то ревертнул до нахождения этого решения.

## Testing Evidence

Ну оно раньше работало

## Why It's Good For The Game

Заклинания с адекватным КД думаю норм тема

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: адекватное кд заклинаний
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
