### PR TITLE
пофиксил спам перезарядкой.

### DIFF
--- a/modular_twilight_axis/code/modules/spell/spell_types/wizard/invoked_aoe/magicshield.dm
+++ b/modular_twilight_axis/code/modules/spell/spell_types/wizard/invoked_aoe/magicshield.dm
@@ -43,6 +43,17 @@
 	
 	return TRUE
 
+/obj/effect/proc_holder/spell/self/magic_shield/charge_check(mob/user) //заглушка для оффкода
+
+
+	if(active)
+		return TRUE
+	
+	if(charge_counter < recharge_time)
+		return FALSE
+		
+	return TRUE
+
 /obj/effect/proc_holder/spell/self/magic_shield/proc/activate_shield(mob/living/user)
 	active = TRUE
 	ranged_ability_user = user

--- a/modular_twilight_axis/code/modules/spell/spell_types/wizard/misc/frost_walker.dm
+++ b/modular_twilight_axis/code/modules/spell/spell_types/wizard/misc/frost_walker.dm
@@ -79,6 +79,17 @@
 	
 	freeze_radius(user)
 
+/obj/effect/proc_holder/spell/self/frost_walker/charge_check(mob/user) //заглушка для оффкода
+
+	if(active)
+		return TRUE
+	
+
+	if(charge_counter < recharge_time)
+		return FALSE
+		
+	return TRUE
+
 /obj/effect/proc_holder/spell/self/frost_walker/proc/deactivate_frost(mob/living/user)
 	if(!active) return
 	active = FALSE


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Теперь два заклинания не спамят перезарядкой.
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:

fix: fixed a few things

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
