### PR TITLE
Убирает таймер для прожатия NECRA.

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -148,8 +148,8 @@
 		var/mob/living/L = usr
 		if(L.stat != DEAD)
 			if(alert("Are you done living?", "", "Yes", "No") == "Yes")
-				if(!L.succumb_timer || (world.time < L.succumb_timer + 111 SECONDS) )
-					var/ttime =  round(((L.succumb_timer + 111 SECONDS) - world.time) / 10)
+				if(!L.succumb_timer || (world.time < L.succumb_timer + 1 SECONDS) ) //TA_Edit
+					var/ttime =  round(((L.succumb_timer + 1 SECONDS) - world.time) / 10) //TA edit
 					to_chat(L, span_redtext("I'm not dead enough yet. [ttime]"))
 				else
 					L.succumb(reaper = TRUE)


### PR DESCRIPTION
## About The Pull Request
Возможность умереть сразу при падении в крит, если игрок нажал на NECRA. 
Не влияет на время смерти игрока в хардкрите, затрагивает только таймер NECRA.

## Testing Evidence
Потестил на локалке, всё работает правильно.

## Why It's Good For The Game
Позволяет умереть тем, кто хочет умереть не дожидаясь таймера.
Избавляет от необходимости пытаться отпаивать раненных, которые не хотят жить и нажмут некру по истечению таймера. 

## Changelog
Изменена задержка перед возможностью умереть с помощью NECRA с 111 секунд до 1.