### PR TITLE
Альтернативные робы в тайник храмовника-виджиланта Эоры.

### DIFF
--- a/modular_twilight_axis/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/modular_twilight_axis/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -361,6 +361,8 @@
 		ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
 		H.cmode_music = 'sound/music/cmode/church/combat_eora.ogg'
 		H.mind.special_items["Alt Tabard"] = /obj/item/clothing/cloak/templar/eoran/alt
+		H.mind.special_items["Pink Robe"] = /obj/item/clothing/suit/roguetown/shirt/robe/eora/resprite/pink
+		H.mind.special_items["Blue Robe"] = /obj/item/clothing/suit/roguetown/shirt/robe/eora/resprite
 	if(H.patron?.type == /datum/patron/divine/malum)
 		H.adjust_skillrank(/datum/skill/craft/blacksmithing, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)


### PR DESCRIPTION
## About The Pull Request

добавляет в тайник обе вариации альтернативных роб виджиланту Эоры, которые изначально есть в тайнике аколитов.


## Testing Evidence

манипуляции с кодом в Visual Studio, компил через батник, тест на локалке и всё работает

## Why It's Good For The Game

Виджилант Эоры спавнится с робой в качестве ''Табарда'' вместо привычного табарда, который есть у того-же паладина. Было бы логично дать ему те самые белые робы на выбор вдобавок к табарду как возможную альтернативу стандартной робе. 

## Changelog
- добавляет в тайник храмовника-виджиланта Эоры альтернативные вариации роб, которые есть в тайнике у аколитов
