### PR TITLE
Модульно добавляю киноварь в магазин бандит-мага.

### DIFF
--- a/modular_twilight_axis/code/modules/cargo/packsrogue/Mage.dm
+++ b/modular_twilight_axis/code/modules/cargo/packsrogue/Mage.dm
@@ -15,5 +15,5 @@
 
 /datum/supply_pack/rogue/Mage/cinnabar
 	name = "Cinnabar Ore"
-	cost = 10
+	cost = 30
 	contains = list(/obj/item/rogueore/cinnabar = 1)


### PR DESCRIPTION
## About The Pull Request

Кривые оффы специально или нет допустили опечатку в коде, из за которой у бандит-мага в магазине не было киновари.
По баг-репорту:
https://discord.com/channels/1133928966915358822/1476855620689989772

## Testing Evidence
На локалке все работает, в магазине мага-бандита появилась киноварь.

## Why It's Good For The Game
Бандит-маг будет лучше помогать банде магическими штучками, в преддверии того, что боевых ролей на стороне города будет ещё больше.

## Changelog
Модульно добавил киноварь в магазин бандит-мага.