### PR TITLE
Кнопка Create Command Report теперь Make IC Announcement.

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -437,10 +437,36 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!input)
 		return
 
+	var/list/sound_options = list("Bell(Base)", "Alert", "HorrorWhispers", "TerribleHorn", "EvilLaugh", "NecromancerLaugh", "Monsters", "OtavaComing", "Custom(file)")
+	var/sound_choice = input(src, "Какой звук?", "Announcement Sound", "Bell(Base)") as null|anything in sound_options
+	if(!sound_choice)
+		return
+
+	var/announce_sound = 'sound/misc/bell.ogg'
+	switch(sound_choice)
+		if("Alert")
+			announce_sound = 'sound/misc/alert.ogg'
+		if("HorrorWhispers")
+			announce_sound = 'sound/misc/carriage3.ogg'
+		if("TerribleHorn")
+			announce_sound = 'sound/misc/carriage4.ogg'
+		if("EvilLaugh")
+			announce_sound = 'sound/misc/HL (1).ogg'
+		if("NecromancerLaugh")
+			announce_sound = 'sound/misc/zizo.ogg'
+		if("Monsters")
+			announce_sound = 'sound/misc/kybraxor.ogg'
+		if("OtavaComing")
+			announce_sound = 'sound/misc/otavanlament.ogg'
+		if("Custom(file)")
+			announce_sound = input(src, "Выбери звуковой файл", "Custom Announcement Sound") as sound|null
+			if(!announce_sound)
+				return
+
 	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No", "Cancel")
 	switch(confirm)
 		if("Yes")
-			priority_announce(input, "<span class='reallybig'>[html_encode(title)]</span>", 'sound/misc/bell.ogg', sender = usr)
+			priority_announce(input, "<span class='reallybig'>[html_encode(title)]</span>", announce_sound, sender = usr)
 		if("Cancel")
 			return
 


### PR DESCRIPTION
## About The Pull Request
Была такая невзрачная кнопка Create Command Report во вкладке "-server-", которая делала голый красный текст на весь сервер (аля анонс герцога), ей никто никогда не пользовался и в общем-то не нужна она была.
Так вот теперь это кнопка "Make IC Announcement" во вкладке -special verbs- (там же, где наррейты). Она вызывает диалоговые окна:
1) Заголовок 2) Текст 3) Выбор звука (можно выбрать файл или готовый) 4) Подтверждение отправки
Подробнее отправлю в скриншотах.
Вряд ли кто-то когда-то будет вообще трогать эту кнопку в коде.
## Testing Evidence
На локалке все работает.
## Why It's Good For The Game
Ивентеры и админы смогут делать красивый анонс, с кастомным или заготовленным звуком. Допустим, ввели антагониста, нужно, чтобы был ЗАМЕТНЫЙ IC анонс? Вот теперь такой можно сделать. Также можно делать ЗАМЕТНЫЕ слухи по городу ивентерам и т.д.. Способов реализации куча. Да, можно было бы делать глобал наррейт, вставлять саунд ручками, но это долго и неудобно. Теперь все делается одной кнопкой и оформлено заранее красиво.
## Changelog
:cl:
add: Make IC Announcement button
/:cl: