### PR TITLE
Hot mana spot

### DIFF
--- a/modular_twilight_axis/code/game/turfs/open/water.dm
+++ b/modular_twilight_axis/code/game/turfs/open/water.dm
@@ -35,3 +35,44 @@
 //		M.visible_message(span_notice("[M] looks a bit better after soaking in the spring."))
 
 	last_heal = world.time
+
+
+/turf/open/water/ocean/deep/scaldingwater
+	name = "Magic flow"
+	desc = "The water is boiling and steaming. It looks like it could energize you, if you can survive the heat."
+	icon = 'icons/turf/roguefloor.dmi'
+	icon_state = "acid"
+	water_color = "#ff7f50"
+	water_reagent = /datum/reagent/water
+	
+
+	var/tick_interval = 2 SECONDS 
+	var/energy_gain = 35 
+	var/fire_damage = 5 
+	var/last_tick = 0
+
+/turf/open/water/ocean/deep/scaldingwater/Initialize()
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/turf/open/water/ocean/deep/scaldingwater/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/turf/open/water/ocean/deep/scaldingwater/process()
+	if(world.time < last_tick + tick_interval)
+		return
+
+	for(var/mob/living/carbon/M in src)
+		if(M.stat == DEAD) 
+			continue
+
+		M.adjustFireLoss(fire_damage)
+		
+		M.energy_add(energy_gain)
+
+		if(prob(5))
+			to_chat(M, span_danger("The water sears your flesh, but adrenaline rushes through you!"))
+			M.emote("gasp")
+
+	last_tick = world.time


### PR DESCRIPTION
## About The Pull Request
Добавил турф воды который регенит ману, модульно по запросу KageIIte
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Затестил на локалке.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Подарок маперам.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
