### PR TITLE
Map votepower is now equal for everyone

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(vote)
 	var/list/voted = list()
 	var/list/voting = list()
 	var/list/generated_actions = list()
-	var/static/list/everyone_is_equal = list("custom", "map")
+	var/static/list/everyone_is_equal = list("custom", "map") // TA EDIT
 
 /datum/controller/subsystem/vote/fire()	//called by master_controller
 	if(mode)


### PR DESCRIPTION
## About The Pull Request

Делает все голоса в голосовании за карту равными.
Предложка: https://discord.com/channels/1133928966915358822/1479205425936339064

## Testing Evidence
Было
<img width="530" height="440" alt="3JBm4SOPxz" src="https://github.com/user-attachments/assets/b46f496e-0cbd-44d2-85af-c70ed5e81b6f" />

Стало
<img width="530" height="440" alt="dreamseeker_aCcKi3BeSk" src="https://github.com/user-attachments/assets/5c7ce3b4-4cd6-445d-91fd-0cbd48e42622" />

## Why It's Good For The Game

Зачастую именно те кто играли в раунде выбирают карту что будет следующей, теперь все голоса равны и будет выбираться карта которую хочет большинство

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
config: Mapwote now has equal votepower for everyone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
