### PR TITLE
Mayor Speech + Realm Rename

### DIFF
--- a/_maps/map_files/dun_world/map_adjustment_dun_world.dm
+++ b/_maps/map_files/dun_world/map_adjustment_dun_world.dm
@@ -6,7 +6,7 @@
 
 /datum/map_adjustment/template/dunworld
 	map_file_name = "dun_world.dmm"
-	realm_name = "Azure Peak"
+	realm_name = "Twilight Axis"
 	blacklist = list(
 		/datum/job/roguetown/royal_guard, 
 		/datum/job/roguetown/sheriff, 

--- a/modular_twilight_axis/code/modules/jobs/job_types/roguetown/enigma_roles/burghers/mayor.dm
+++ b/modular_twilight_axis/code/modules/jobs/job_types/roguetown/enigma_roles/burghers/mayor.dm
@@ -97,6 +97,7 @@
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Savings.")
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/writeresidentscroll)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/mayor_announcement)
 
 /obj/item/clothing/head/roguetown/chaperon/noble/mayor
 	name = "Mayor's chaperon"
@@ -168,3 +169,33 @@
 	qdel(sacrifice)
 	H.put_in_hands(new /obj/item/book/granter/residentcard, TRUE)
 
+/obj/effect/proc_holder/spell/self/mayor_announcement
+	name = "The Mayor's Speech"
+	desc = "Let your word be heard by everyone on this city and near of it. You need streetpipe to speak."
+	overlay_state = "paper"
+	action_icon = 'modular_twilight_axis/icons/mob/actions/roguespells.dmi'
+	releasedrain = 40
+	chargetime = 1 SECONDS
+	recharge_time = 5 MINUTES
+	warnie = "spellwarning"
+	antimagic_allowed = FALSE
+	charging_slowdown = 3
+
+/obj/effect/proc_holder/spell/self/mayor_announcement/cast(list/targets, mob/living/user = usr)
+	var/turf/T = get_step(user, user.dir)
+	if(!(locate(/obj/structure/broadcast_horn/paid) in T))
+		to_chat(user, span_warning("I need streetpipe to speak.")) 
+		revert_cast()
+		return
+	if(!SScommunications.can_announce(user, FALSE))
+		to_chat(user, span_warning("You are not ready to speak yet."))
+		revert_cast()
+		return FALSE
+	var/message = stripped_input(user, "What message do you wish to broadcast to the this land?", "The Mayor's Speech", "")
+	if(!message || QDELETED(src) || user.stat != CONSCIOUS)
+		revert_cast()
+		return FALSE
+	var/used_title = "Mayor"
+	priority_announce(html_decode(user.treat_message(message)), "[used_title] Speak", 'sound/misc/bellold.ogg', sender = user)
+	log_game("[key_name(user)] used The Mayor's Speech: [message]")
+	return TRUE


### PR DESCRIPTION
## About The Pull Request
-Новая способность для Мэра делать массовое оповещение раз в 5 минут. Для этого мэру нужно стоять у любого Streetpipe (1 есть в его особняке и ещё несколько в городе, включая общедоступный streetpipe в доме глашатая). -Поменял название реалма "Azure Peak" на "Twilight Axis".

## Testing Evidence
Проверил на локалке, всё работает как нужно.

## Why It's Good For The Game
Мэру, как одной из главных фигур города не хватает опции делать массовые объявления.

## Changelog
add: Мэр может делать массовое объявление.
fix: Изменено название реалма с "Azure Peak" на "Twilight Axis"