### PR TITLE
[DNM/TM ONLY] нерф крита от берна

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -786,7 +786,7 @@
 		if(!(bodypart.body_zone in lethal_zones))
 			continue
 		
-		total_burn_percent += (bodypart.burn_dam / bodypart.max_damage)
+		total_burn_percent += max(0, bodypart.burn_dam / bodypart.max_damage)
 		checked_lethal_zones++
 
 	if(checked_lethal_zones)


### PR DESCRIPTION
## About The Pull Request
это временное решение только на тестмерж, пока оффы сами не решат как забалансить магов

после ребалансов урона спеллов/меток чаще начали жаловаться на 5-10 секундные бои с магами, где за 1 прокаст вылетает некра

Для крита от огня теперь должен быть надамажен торс и голова, а не только голова

## Testing Evidence
da

## Why It's Good For The Game
выше

## Changelog
:cl:
code: для крита от огня учитываются голова и торс
/:cl: