### PR TITLE
Делает тесак серебряным

### DIFF
--- a/modular_twilight_axis/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/modular_twilight_axis/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -110,7 +110,7 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel/necra/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
-		pre_blessed = BLESSING_NONE,\
+		pre_blessed = BLESSING_TENNITE,\
 		silver_type = SILVER_TENNITE,\
 		added_force = 0,\
 		added_blade_int = 50,\


### PR DESCRIPTION
## About The Pull Request

Оружие некритов, кроме их тесаков, серебряное. Теперь тесаки тоже серебряные.

## Testing Evidence

<img width="438" height="191" alt="image" src="https://github.com/user-attachments/assets/fc3e07b2-2e9e-4ac5-9f2d-bd3395a7f76d" />

## Why It's Good For The Game

Резать скелетов круто, особенно с учетом оторванного ритуала. 

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Теперь Остеотомы серебряные
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
