### PR TITLE
Фикс абуза лестниц

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -50,12 +50,24 @@
 		if(partner.dir == dir)	//partner matches our dir
 			return newtarg
 
-/obj/structure/stairs/proc/user_walk_into_target_loc(atom/movable/AM, dirmove)
+/obj/structure/stairs/proc/user_walk_into_target_loc(atom/movable/AM, dirmove) // TA EDIT START
 	var/turf/newtarg = get_target_loc(dirmove)
-	if(newtarg)
-		INVOKE_ASYNC(src, GLOBAL_PROC_REF(movable_travel_z_level), AM, newtarg)
-		return TRUE
-	return FALSE
+	if(!newtarg)
+		return FALSE
+
+	INVOKE_ASYNC(src, PROC_REF(travel_with_stamina_cost), AM, newtarg)
+	return TRUE
+
+/obj/structure/stairs/proc/travel_with_stamina_cost(atom/movable/AM, turf/newtarg)
+	if(!AM || !newtarg)
+		return
+
+	movable_travel_z_level(AM, newtarg)
+
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		if(H.mind)
+			H.stamina_add(15, null, FALSE) // TA EDIT END
 
 /obj/structure/stairs/stone
 	name = "stone stairs"


### PR DESCRIPTION
## About The Pull Request

Теперь при спуске и поднятию по лестнице отнимает стамину. Зачем? Потому что многие надмозги это абузят в боевке. Это всегда было раковой херней на рогтаун билдах. В случае чего, понижу или подниму трату стамины или как-либо переделаю, ибо это все пока что как эксперимент.

## Testing Evidence

Я запустил локалку, оно работает.

## Why It's Good For The Game

Меньше табакси-бандитов бегающих по лестнице вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх вниз вверх 

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: трата стамины при поднятии и спуске с лестницы
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
