### PR TITLE
[NON MOD] Longstrider for wardens/poachers and etc

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -90,7 +90,7 @@
 		return
 	if(!victim.ambushable())
 		return
-	if(victim.m_intent == MOVE_INTENT_SNEAK)
+	if(victim.m_intent == MOVE_INTENT_SNEAK || HAS_TRAIT(victim, TRAIT_AZURENATIVE)) // TA_EDIT +HAS_TRAIT(victim, TRAIT_AZURENATIVE)
 		return
 
 	buckle_mob(victim, TRUE, check_loc = FALSE)

--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -497,6 +497,11 @@
 	. = ..()
 	var/negate_slowdown = FALSE
 
+	for(var/obj/item/stick in user.held_items)  // TA EDIT START
+		if(stick.walking_stick && !stick.wielded && !user.cmode) // 
+			negate_slowdown = TRUE //
+			break // TA EDIT FIN
+
 	if((isliving(user))&&(user?.movement_type == FLYING))
 		negate_slowdown = TRUE
 	if(HAS_TRAIT(user, TRAIT_LONGSTRIDER))

--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -508,7 +508,7 @@
 		negate_slowdown = TRUE
 
 	if(negate_slowdown)
-		. -= 2
+		. -= 1 // TA EDIT 2 —> 1 (since slowdown numbers were changed)
 	return max(., 0)
 
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
@@ -7,7 +7,7 @@
 	cmode_music = 'sound/music/combat_poacher.ogg'
 	class_select_category = CLASS_CAT_RANGER
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_AZURENATIVE, TRAIT_DODGEEXPERT, TRAIT_WOODSMAN, TRAIT_OUTDOORSMAN, TRAIT_SURVIVAL_EXPERT, TRAIT_EXPERT_HUNTER)
+	traits_applied = list(TRAIT_LONGSTRIDER, TRAIT_DODGEEXPERT, TRAIT_WOODSMAN, TRAIT_OUTDOORSMAN, TRAIT_SURVIVAL_EXPERT, TRAIT_EXPERT_HUNTER) // TA EDIT TRAIT_AZURENATIVE —> TRAIT_LONGSTRIDER
 	// No straight upgrade to perception / speed to not stack one stat too high, but still stronger than MAA Skirm out of town.
 	subclass_stats = list(
 		STATKEY_PER = 3,

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -26,7 +26,7 @@
 	same_job_respawn_delay = 30 MINUTES
 
 	cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg'
-	job_traits = list(TRAIT_AZURENATIVE, TRAIT_OUTDOORSMAN, TRAIT_WOODSMAN, TRAIT_SURVIVAL_EXPERT, TRAIT_EXPERT_HUNTER)
+	job_traits = list(TRAIT_LONGSTRIDER, TRAIT_OUTDOORSMAN, TRAIT_WOODSMAN, TRAIT_SURVIVAL_EXPERT, TRAIT_EXPERT_HUNTER) // TA EDIT TRAIT_AZURENATIVE —> TRAIT_LONGSTRIDER
 	job_subclasses = list(/datum/advclass/warden/warden)
 
 /datum/outfit/job/roguetown/warden


### PR DESCRIPTION
## About The Pull Request
 Upstream decided to remove longstrider from wardens... dunno why they had any issues with those creeps, but whatever
Azurenative was replaced with longstrider
Azurenative doesn't trigger maneaters (<— quinallion's change)
Walking sticks are back and negate slowdown effects for dirty turfs
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1ebfadb6-073f-4acd-a26c-c237d53f0fb2" />
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Why it's not, also there was a suggestion made in discord I'll provide a link to it later
https://discord.com/channels/1133928966915358822/1495129389392990508
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
replaced azurenative  with longstrider for wardens and poachers
walking sticks remove slowdown from dirt
azurenative doesn't trigger maneaters 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
