### PR TITLE
Убирает возможность выбрать пронаунс и тип тела для скелетов лича

### DIFF
--- a/code/modules/spells/spell_types/undead/summon/raise_undead.dm
+++ b/code/modules/spells/spell_types/undead/summon/raise_undead.dm
@@ -55,7 +55,7 @@
 	target.copy_known_languages_from(user, TRUE)
 	target.visible_message(span_warning("[target]'s eyes light up with an eerie glow!"))
 	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, choose_name_popup), "FORTIFIED SKELETON"), 3 SECONDS)
-	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, choose_pronouns_and_body)), 7 SECONDS)
+	//addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, choose_pronouns_and_body)), 7 SECONDS) //TA_EDIT
 	target.mind.AddSpell(new /obj/effect/proc_holder/spell/self/suicidebomb/lesser)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Убирает возможность выбрать пронаунс и тип тела для скелетов лича.

## Testing Evidence
Локалка.

## Why It's Good For The Game
Скелетам лича не нужен выбор пронаунса и типа тела, т.к. оно уже наследуется от выбранного персонажа в слоте. 
Эти 2 всплывающих окошка лишь бесят и были добавлены соевыми пиндосами с их угаром по ЛГБТКТКЫВЫФВЫФ+
