### PR TITLE
Лок этруского ориджина для конкистадора 

### DIFF
--- a/modular_twilight_axis/lore/code/jobs/merc_origins.dm
+++ b/modular_twilight_axis/lore/code/jobs/merc_origins.dm
@@ -102,3 +102,6 @@
 
 /datum/advclass/mercenary/underdweller
 	origin_limits = list(/datum/virtue/origin/racial/underdark, /datum/virtue/origin/racial/underdark_drow, /datum/virtue/origin/racial/akhdruk)
+
+/datum/advclass/mercenary/twilight_conquistador
+	origin_limits = list(/datum/virtue/origin/etrusca)


### PR DESCRIPTION
## About The Pull Request

Добавляет лок на ориджин Этруски для конкистадора - особого наёмника из Этруски, первоначальная причина отсутствия подобного запрета является незнание оригинального разработчика о том, как добавить лок.

## Testing Evidence
Оно запускается и оно работает.
![Uploading CWyHIMU4un.png…]()

## Why It's Good For The Game

Этруский наёмник - должен быть из Этруски.

## Changelog

:cl:
add: лок ориджина для этруского наёмника
/:cl:
