### PR TITLE
Фикс стелс-мода админов

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -325,7 +325,7 @@
 		if(C && C.holder && C.holder.fakekey && !include_name)
 			if(include_link)
 				. += "<a href='?priv_msg=[C.findStealthKey()]'>"
-			. += "Administrator"
+			. += C.holder.fakekey // TA EDIT
 		else
 			if(include_link)
 				. += "<a href='?priv_msg=[ckey]'>"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -45,7 +45,14 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	. = ..()
 
 /datum/admin_help_tickets/proc/IsAdminInHideCharname(ckey)
-	return (ckey in admin_hide_charname)
+// TA EDIT BEGIN
+	if(ckey in admin_hide_charname)
+		return TRUE
+	var/client/C = GLOB.directory[ckey]
+	if(C && C.holder && C.holder.fakekey)
+		return TRUE
+	return FALSE
+// TA EDIT END
 
 /datum/admin_help_tickets/proc/SaveHideCharname()
 	var/path = "data/admin_hide_charname.json"
@@ -96,8 +103,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			var/datum/admin_help/AH = ticket_list[I]
 			if(AH.id > new_ticket.id)
 				ticket_list.Insert(I, new_ticket)
+				SStgui.update_uis(GLOB.ahelp_tickets) // TA EDIT
 				return
 	ticket_list += new_ticket
+	SStgui.update_uis(GLOB.ahelp_tickets) // TA EDIT
 
 //opens the ticket listings for one of the 3 states
 /datum/admin_help_tickets/proc/BrowseTickets(state)
@@ -486,7 +495,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			if(embed_type != "image" && embed_type != "video")
 				return FALSE
 			var/prefix = embed_type == "image" ? "EMBED_IMAGE:" : "EMBED_VIDEO:"
-			var/show_charname = !GLOB.ahelp_tickets.IsAdminInHideCharname()
+			var/show_charname = !GLOB.ahelp_tickets.IsAdminInHideCharname(user.ckey) // TA EDIT
 			ticket.AddInteraction("<font color='blue'>PM from [key_name_admin(user, show_charname)]: [prefix][url]</font>")
 			// Notify the player if connected
 			if(ticket.initiator)
@@ -597,15 +606,16 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		MessageNoRecipient(msg, newticket = TRUE)
 
 	GLOB.ahelp_tickets.active_tickets += src
-	
-	// Open the TGUI chat window for the initiator
-	if(C && C.mob)
-		ui_interact(C.mob)
+	SStgui.update_uis(GLOB.ahelp_tickets) // TA EDIT
 
+	// Open the TGUI chat window for the initiator
+	if(C && C.mob && !is_bwoink) // TA EDIT
+		ui_interact(C.mob)
 /datum/admin_help/Destroy()
 	RemoveActive()
 	GLOB.ahelp_tickets.closed_tickets -= src
 	GLOB.ahelp_tickets.resolved_tickets -= src
+	SStgui.update_uis(GLOB.ahelp_tickets) // TA EDIT
 	return ..()
 
 /datum/admin_help/proc/AddInteraction(formatted_message, player_message)
@@ -657,8 +667,15 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 /datum/admin_help/proc/MessageNoRecipient(msg, play_sound = TRUE, newticket = FALSE)
 	msg = copytext_char(msg, 1, MAX_MESSAGE_LEN)
 	var/ref_src = "[REF(src)]"
+// TA EDIT BEGIN
+	var/display_ckey = initiator_ckey
+	if(initiator && initiator.holder && initiator.holder.fakekey && !GLOB.ahelp_tickets.IsAdminInHideCharname(initiator_ckey))
+		display_ckey = initiator.holder.fakekey
+	else if(initiator && initiator.holder && initiator.holder.fakekey)
+		display_ckey = initiator.holder.fakekey
+// TA EDIT END
 	// Simplified message to be sent to all admins, including title and action links
-	var/admin_msg = span_adminnotice("<font color='#c87941'><b>Ticket #[id]: ([initiator_ckey]) - [TicketHref("Show Ticket", ref_src)]</b><br><span class='linkify' style='font-weight:normal;color:#c87941'>[msg]</span></font>")
+	var/admin_msg = span_adminnotice("<font color='#c87941'><b>Ticket #[id]: ([display_ckey]) - [TicketHref("Show Ticket", ref_src)]</b><br><span class='linkify' style='font-weight:normal;color:#c87941'>[msg]</span></font>")
 
 	AddInteraction("<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>", player_message = "<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>")
 
@@ -703,6 +720,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	GLOB.ahelp_tickets.active_tickets += src
 	GLOB.ahelp_tickets.closed_tickets -= src
 	GLOB.ahelp_tickets.resolved_tickets -= src
+	SStgui.update_uis(GLOB.ahelp_tickets) // TA EDIT
 	switch(state)
 		if(AHELP_CLOSED)
 			SSblackbox.record_feedback("tally", "ahelp_stats", -1, "closed")
@@ -884,10 +902,13 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(new_title)
 		name = new_title
 		//not saying the original name cause it could be a long ass message
-		var/msg = "Ticket [TicketHref("#[id]")] titled [name] by [key_name_admin(usr)]"
+// TA EDIT BEGIN
+		var/show_charname = !GLOB.ahelp_tickets.IsAdminInHideCharname(usr.ckey)
+		var/msg = "Ticket [TicketHref("#[id]")] titled [name] by [key_name_admin(usr, show_charname)]"
 		message_admins(msg)
 		log_admin_private(msg)
-		AddInteraction("Retitled by [key_name_admin(usr)]")
+		AddInteraction("Retitled by [key_name_admin(usr, show_charname)]")
+// TA EDIT END
 
 //Forwarded action from admin/Topic
 /datum/admin_help/proc/Action(action)
@@ -1132,9 +1153,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			if(embed_type != "image" && embed_type != "video")
 				return FALSE
 			var/prefix = embed_type == "image" ? "EMBED_IMAGE:" : "EMBED_VIDEO:"
-			AddInteraction("<font color='blue'>PM from [key_name_admin(usr)]: [prefix][url]</font>")
+// TA EDIT BEGIN
+			var/show_charname = !GLOB.ahelp_tickets.IsAdminInHideCharname(usr.ckey)
+			AddInteraction("<font color='blue'>PM from [key_name_admin(usr, show_charname)]: [prefix][url]</font>")
 			if(initiator)
-				to_chat(initiator, span_adminhelp("<b>Admin [key_name_admin(usr)] embedded a [embed_type] in your ticket.</b>"))
+				to_chat(initiator, span_adminhelp("<b>Admin [key_name_admin(usr, show_charname)] embedded a [embed_type] in your ticket.</b>"))
+// TA EDIT END
 			log_admin_private("Ticket #[id]: [key_name(usr)] embedded [embed_type]: [url]")
 			return TRUE
 
@@ -1218,7 +1242,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			else
 				to_chat(usr, span_warning("Ticket not found, creating new one..."))
 		else
-			current_ticket.AddInteraction("[key_name_admin(usr)] opened a new ticket.", player_message = "opened a new ticket.")
+			var/show_charname = !GLOB.ahelp_tickets.IsAdminInHideCharname(usr.ckey) // TA EDIT
+			current_ticket.AddInteraction("[key_name_admin(usr, show_charname)] opened a new ticket.", player_message = "opened a new ticket.") // TA EDIT
 			current_ticket.Close()
 
 	new /datum/admin_help(msg, src, FALSE)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -29,35 +29,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	// Track selected ticket per user
 	var/list/selected_tickets = list()  // Maps ckey -> ticket_id
 
-	/// Ckeys of admins who have opted to hide their character name in ticket messages. Persisted to disk.
-	var/list/admin_hide_charname = list()
-
 	var/obj/effect/statclick/ticket_list/astatclick = new(null, null, AHELP_ACTIVE)
 	var/obj/effect/statclick/ticket_list/cstatclick = new(null, null, AHELP_CLOSED)
 	var/obj/effect/statclick/ticket_list/rstatclick = new(null, null, AHELP_RESOLVED)
 
-/datum/admin_help_tickets/New()
-	var/json_data = file2text("data/admin_hide_charname.json")
-	if(json_data)
-		var/list/loaded = safe_json_decode(json_data)
-		if(islist(loaded))
-			admin_hide_charname = loaded
-	. = ..()
-
 /datum/admin_help_tickets/proc/IsAdminInHideCharname(ckey)
-// TA EDIT BEGIN
-	if(ckey in admin_hide_charname)
-		return TRUE
-	var/client/C = GLOB.directory[ckey]
-	if(C && C.holder && C.holder.fakekey)
-		return TRUE
-	return FALSE
-// TA EDIT END
-
-/datum/admin_help_tickets/proc/SaveHideCharname()
-	var/path = "data/admin_hide_charname.json"
-	fdel(path)
-	WRITE_FILE(path, json_encode(admin_hide_charname))
+	return TRUE
 
 /datum/admin_help_tickets/Destroy()
 	QDEL_LIST(active_tickets)
@@ -208,8 +185,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			full_ticket["initiator_connected"] = selected.initiator ? TRUE : FALSE
 			data["selected_ticket"] = full_ticket
 
-	// Whether this admin has opted to hide their character name in ticket messages
-	data["admin_hide_charname"] = (user.ckey in admin_hide_charname)
+	// Whether this admin is currently in stealth mode
+	data["admin_hide_charname"] = user.client?.holder?.fakekey ? TRUE : FALSE
 
 	return data
 
@@ -237,12 +214,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			return TRUE
 
 		if("toggle_charname")
-			// Toggle whether this admin's character name is hidden in ticket messages.
-			if(user.ckey in admin_hide_charname)
-				admin_hide_charname -= user.ckey
-			else
-				admin_hide_charname += user.ckey
-			SaveHideCharname()
+			if(user.client)
+				INVOKE_ASYNC(user.client, TYPE_PROC_REF(/client, stealth))
 			return TRUE
 
 		if("send_message")

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -52,12 +52,12 @@
 		return
 
 	var/datum/admin_help/AH = C.current_ticket
-
+	var/show_charname = !GLOB.ahelp_tickets.IsAdminInHideCharname(src.ckey) // TA EDIT
 	if(AH)
-		message_admins("[key_name_admin(src)] has started replying to [key_name_admin(C, 0, 0)]'s admin help.")
+		message_admins("[key_name_admin(src, show_charname)] has started replying to [key_name_admin(C, 0, 0)]'s admin help.") // TA EDIT
 	var/msg = input(src,"Message:", "Private message to [C.holder?.fakekey ? "an Administrator" : key_name(C, 0, 0)].") as message|null
 	if (!msg)
-		message_admins("[key_name_admin(src)] has cancelled their reply to [key_name_admin(C, 0, 0)]'s admin help.")
+		message_admins("[key_name_admin(src, show_charname)] has cancelled their reply to [key_name_admin(C, 0, 0)]'s admin help.") // TA EDIT
 		return
 	cmd_admin_pm(whom, msg)
 	. = list(AH, msg)
@@ -118,13 +118,14 @@
 		//get message text, limit it's length.and clean/escape html
 		if(!msg)
 			var/datum/admin_help/sender_ticket = !holder ? current_ticket : null
+			var/show_charname_prompt = !GLOB.ahelp_tickets.IsAdminInHideCharname(src.ckey) // TA EDIT
 			if(sender_ticket)
-				message_admins("[key_name_admin(src)] has started replying to their admin help.")
+				message_admins("[key_name_admin(src, show_charname_prompt)] has started replying to their admin help.") // TA EDIT
 			msg = input(src,"Message:", "Private message to [recipient.holder?.fakekey ? "an Administrator" : key_name(recipient, 0, 0)].") as message|null
 			msg = trim(msg)
 			if(!msg)
 				if(sender_ticket)
-					message_admins("[key_name_admin(src)] has cancelled their reply to their admin help.")
+					message_admins("[key_name_admin(src, show_charname_prompt)] has cancelled their reply to their admin help.") // TA EDIT
 				return
 
 			if(prefs.muted & MUTE_ADMINHELP)
@@ -156,8 +157,9 @@
 		//msg = emoji_parse(msg)
 
 	var/keywordparsedmsg = keywords_lookup(msg)
+	var/show_charname = !GLOB.ahelp_tickets.IsAdminInHideCharname(src.ckey) // TA EDIT
 	/// Stores a bit of html with our ckey, name, and a linkified string to click and rely to us with
-	var/name_key_with_link = key_name(src, TRUE, TRUE)
+	var/name_key_with_link = key_name_admin(src, show_charname) // TA EDIT
 
 	if(irc)
 		to_chat(src, span_notice("PM to-<b>Admins</b>: <span class='linkify'>[rawmsg]</span>"))
@@ -209,9 +211,9 @@
 			to_chat(recipient, span_adminsay("<i><a href='?viewticket=1'>View ticket</a></i>"))
 			to_chat(src, span_notice("Admin PM to-<b>[key_name(recipient, src, 1)]</b>: <span class='linkify'>[msg]</span>"))
 
-			message_admins_without(span_notice("Admin PM from <b>[src]</b> to-<b>[key_name(recipient)]</b>: <span class='linkify'>[msg]</span>"), src)
+			message_admins_without(span_notice("Admin PM from <b>[name_key_with_link]</b> to-<b>[key_name(recipient)]</b>: <span class='linkify'>[msg]</span>"), src) // TA EDIT
 
-			admin_ticket_log(recipient, "<font color='purple'>PM From [key_name_admin(src)]: [keywordparsedmsg]</font>")
+			admin_ticket_log(recipient, "<font color='purple'>PM From [name_key_with_link]: [keywordparsedmsg]</font>") // TA EDIT
 			//always play non-admin recipients the adminhelp sound
 			SEND_SOUND(recipient, sound('sound/adminhelp.ogg'))
 
@@ -225,7 +227,7 @@
 				GLOB.ahelp_tickets.selected_tickets[usr.ckey] = created_ticket.id
 				GLOB.ahelp_tickets.ui_interact(usr)
 			if(!newticket)
-				created_ticket.AddInteraction("<font color='blue'>PM from [key_name_admin(src)]: [msg]</font")
+				created_ticket.AddInteraction("<font color='blue'>PM from [name_key_with_link]: [msg]</font>") // TA EDIT
 				var/list/data = list(
 					"type"= "areply",
 					"id"= "[created_ticket.id]",

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -202,7 +202,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		update_preferences(needs_update, S)		//needs_update = savefile_version if we need an update (positive integer)
 
 	//Sanitize
-	asaycolor		= sanitize_ooccolor(sanitize_hexcolor(asaycolor, 6, 1, initial(asaycolor)))
+	asaycolor		= sanitize_hexcolor(asaycolor, 6, 1, initial(asaycolor)) // TA EDIT
 	ooccolor		= sanitize_ooccolor(sanitize_hexcolor(ooccolor, 6, 1, initial(ooccolor)))
 	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
 	UI_style		= sanitize_inlist(UI_style, GLOB.available_ui_styles, GLOB.available_ui_styles[1])

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -765,7 +765,7 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		return
 	var/new_asaycolor = input(src, "Please select your ASAY color.", "ASAY color", prefs.asaycolor) as color|null
 	if(new_asaycolor)
-		prefs.asaycolor = sanitize_ooccolor(new_asaycolor)
+		prefs.asaycolor = sanitize_hexcolor(new_asaycolor) // TA EDIT
 		prefs.save_preferences()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Set ASAY Color")
 	return

--- a/tgui/packages/tgui/interfaces/AdminTicketPanel.tsx
+++ b/tgui/packages/tgui/interfaces/AdminTicketPanel.tsx
@@ -601,13 +601,13 @@ export const AdminTicketPanel = (props) => {
                                   icon="user-secret"
                                   tooltip={
                                     admin_hide_charname
-                                      ? 'Character name hidden — click to show it'
-                                      : 'Character name visible — click to hide it'
+                                      ? 'Stealth Mode Active — click to disable'
+                                      : 'Stealth Mode Inactive — click to enable'
                                   }
                                   selected={!!admin_hide_charname}
                                   onClick={() => act('toggle_charname')}
                                 >
-                                  {admin_hide_charname ? 'Anon' : 'Named'}
+                                  {admin_hide_charname ? 'Stealth ON' : 'Stealth OFF'}
                                 </Button>
                                 <Button
                                   icon="image"


### PR DESCRIPTION
## About The Pull Request
Этот ПР чинит сломанную механику стелс-мода, которая после введения новой ТГУИ-панельки для тикетов стала работать некорректно. Конкретнее: 
1. Стелс-мод заменяет сикей на фейковый корректно, в т.ч. и во вложениях (картинки-видео) и при системных оповещениях (закрытие/открытие тикетов/тп)
2. Функция анонимности ТГУИ-панельки тикетов работает корректно (имя персонажа админа не отображается ни при каких обстоятельствах)
## Testing Evidence
Оно заработало, подробности смотрите в видео -> https://youtu.be/YpE8ms2xH5E?si=PoHti5U59_y1NAIE
## Why It's Good For The Game
Меня это раздражало, решил поправить как умею.
## Changelog
:cl:
fix: Пофикшена анонимность администратора через стелс-мод и анонимность ТГУИ-панельки тикетов.
/:cl: