### PR TITLE
Пули теперь воспринимают броню

### DIFF
--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -57,7 +57,7 @@
 
 /datum/armor/proc/getRating(rating)
 	switch(rating)
-		if("blunt", "slash", "stab", "piercing", "fire", "acid", "magic")
+		if("blunt", "slash", "stab", "piercing", "fire", "acid", "magic", "bullet")
 			return vars[rating]
 	stack_trace("getRating called with unknown rating key [rating] — fix the caller")
 	return 0

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -57,7 +57,7 @@
 
 /datum/armor/proc/getRating(rating)
 	switch(rating)
-		if("blunt", "slash", "stab", "piercing", "fire", "acid", "magic", "bullet")
+		if("blunt", "slash", "stab", "piercing", "fire", "acid", "magic", "bullet") // TA EDIT
 			return vars[rating]
 	stack_trace("getRating called with unknown rating key [rating] — fix the caller")
 	return 0

--- a/modular_twilight_axis/firearms/code/weapons/ammo.dm
+++ b/modular_twilight_axis/firearms/code/weapons/ammo.dm
@@ -186,14 +186,16 @@
 		max_range = gun.effective_range
 	..()
 
-/obj/projectile/bullet/on_hit(atom/target)
+/obj/projectile/bullet/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/mob/living/T = target
 		if(istype(fired_from, /obj/item/gun/ballistic/twilight_firearm)) //Double damage in close range
 			var/is_within_effective_range = !check_range(get_turf(target))
 			if(is_within_effective_range)
-				if(!istype(T.get_inactive_held_item(), /obj/item/rogueweapon/shield) && !istype(T.get_active_held_item(), /obj/item/rogueweapon/shield))
-					switch(gunpowder) //Hande gunpowder types that are BLOCKED by shields and armor
+				var/has_projectile_shield = istype(T.get_inactive_held_item(), /obj/item/rogueweapon/shield) || istype(T.get_active_held_item(), /obj/item/rogueweapon/shield)
+				var/armor_softened = blocked > 0
+				if(!has_projectile_shield && !armor_softened)
+					switch(gunpowder) //Handle gunpowder types that are BLOCKED by shields and armor
 						if("fyrepowder")
 							if(istype(src, /obj/projectile/bullet/twilight_grapeshot))
 								T.adjust_fire_stacks(2)
@@ -234,7 +236,7 @@
 						if("terrorpowder")
 							gunpowder_npc_critfactor += 1
 				else
-					switch(gunpowder) //Hande gunpowder types that are NOT BLOCKED by shields and armor
+					switch(gunpowder) //Handle gunpowder types that are NOT BLOCKED by shields and armor
 						if("fyrepowder")
 							if(istype(src, /obj/projectile/bullet/twilight_grapeshot))
 								T.adjust_fire_stacks(1)
@@ -390,7 +392,7 @@
 				H.set_silence(5 SECONDS)
 
 /obj/projectile/bullet/twilight_cannonball/on_hit(atom/target, blocked = FALSE)
-	. = ..()
+	. = ..(target, blocked)
 
 	var/turf/epicenter = get_turf(target)
 	if(!epicenter)


### PR DESCRIPTION
## About The Pull Request

Исправил прикол с тем, что пулям было плевать на то, что существует такое понятие как 30 кг чугуна на человеке, через которые пули проходили на сквозь и наносили полный дамаг, ни как не снижаясь. В этом, конечно же, был еще и замешан Райан. Без него ни как.

## Testing Evidence

1. <img width="391" height="411" alt="image" src="https://github.com/user-attachments/assets/19ab4065-4cf5-4270-9221-5ead59686a30" />

2. <img width="220" height="100" alt="image" src="https://github.com/user-attachments/assets/f0987245-6253-40a4-b4cc-2eab417f5bd1" />

3. Вместо 140 урона получил поменьше мужик

## Why It's Good For The Game

Работающая броня это круто

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Исправлен пофигизм пуль на броню, броня снова режет урон от пуль и получает от них дамаг
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
