### PR TITLE
Укусы и пинки теперь убирают инвиз

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -82,6 +82,7 @@
 
 	next_attack_msg.Cut()
 
+	user.break_invisibility_from_combat()
 	user.do_attack_animation(src, "bite")
 	playsound(user, 'sound/gore/flesh_eat_01.ogg', vol = 50, vary = FALSE, extrarange = -2, ignore_walls = FALSE, quiet = TRUE)
 	var/nodmg = FALSE
@@ -252,6 +253,7 @@
 		return FALSE*/
 
 	user.changeNext_move(CLICK_CD_GRABBING)
+	user.break_invisibility_from_combat()
 	var/mob/living/carbon/C = grabbed
 	var/damage = user.get_punch_dmg()
 	if(HAS_TRAIT(user, TRAIT_STRONGBITE))
@@ -276,7 +278,7 @@
 							if(W.werewolf_infect_attempt())
 								infected = TRUE
 								break
-						
+
 						if(infected)
 							to_chat(user, span_boldnotice("I have delivered the gift to [C] while chewing on their [parse_zone(sublimb_grabbed)]!"))
 
@@ -328,4 +330,5 @@
 		to_chat(user, span_warning("Sigh. It's not bleeding."))
 		return
 
+	user.break_invisibility_from_combat()
 	user.drinksomeblood(grabbed, sublimb_grabbed)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -373,6 +373,7 @@
 
 	if(can_inject(M, 1, affecting))//Thick suits can stop monkey bites.
 		if(..()) //successful monkey bite, this handles disease contraction.
+			M.break_invisibility_from_combat()
 			var/damage = rand(1, 3)
 			if(check_shields(M, damage, "the [M.name]"))
 				return 0

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1282,6 +1282,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(!target.lying_attack_check(user))
 			return 0
 
+		user.break_invisibility_from_combat()
 		var/armor_block = target.run_armor_check(selzone, "blunt", armor_penetration = PEN_NONE, blade_dulling = user.used_intent.blade_class, damage = damage, intdamfactor = user.used_intent?.intent_intdamage_factor)
 
 		target.lastattacker = user.real_name
@@ -1290,6 +1291,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		target.lastattackerckey = user.ckey
 		target.lastattacker_weakref = WEAKREF(user)
 		user.dna.species.spec_unarmedattacked(user, target)
+		user.break_invisibility_from_combat()
 
 		target.next_attack_msg.Cut()
 
@@ -1554,6 +1556,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		stander = FALSE
 	if(!get_dist(user, target))
 		if(!stander)
+			user.break_invisibility_from_combat()
 			target.lastattacker = user.real_name
 			target.lastattackerckey = user.ckey
 			target.lastattacker_weakref = WEAKREF(user)
@@ -1591,6 +1594,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	else
 		if(!target.kick_attack_check(user))
 			return 0
+		user.break_invisibility_from_combat()
 		user.do_attack_animation_simple(target, ATTACK_EFFECT_KICK, TRUE)
 		playsound(target, 'sound/combat/hits/kick/kick.ogg', 100, TRUE, -1)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -61,10 +61,19 @@
 				if(dullness_ratio <= SHARPNESS_TIER2_THRESHOLD)	//Our weapon is CHUNKED. What are we PENNING WITH.
 					blocked = block_damage * 10
 
+	break_invisibility_from_combat()
+	return blocked
+
+/mob/living/proc/break_invisibility_from_combat()
+	var/should_update_invis = FALSE
+	if(vars["rogue_sneaking"])
+		mob_timers[MT_FOUNDSNEAK] = world.time
+		should_update_invis = TRUE
 	if(mob_timers[MT_INVISIBILITY] > world.time)
 		mob_timers[MT_INVISIBILITY] = world.time
+		should_update_invis = TRUE
+	if(should_update_invis)
 		update_sneak_invis(reset = TRUE)
-	return blocked
 
 #define SHARPNESS_PENALTY_RATIO_ONE 0.7
 #define SHARPNESS_PENALTY_RATIO_TWO 0.6
@@ -578,6 +587,7 @@
 		if (prob(75))
 			log_combat(M, src, "attacked")
 			playsound(loc, 'sound/blank.ogg', 50, TRUE, -1)
+			M.break_invisibility_from_combat()
 			visible_message(span_danger("[M.name] bites [src]!"), \
 							span_danger("[M.name] bites you!"), span_hear("I hear a chomp!"), COMBAT_MESSAGE_RANGE, M)
 			to_chat(M, span_danger("I bite [src]!"))
@@ -608,6 +618,7 @@
 		if (prob(75))
 			log_combat(M, src, "attacked")
 			playsound(loc, 'sound/blank.ogg', 50, TRUE, -1)
+			M.break_invisibility_from_combat()
 			visible_message(span_danger("[M.name] bites [src]!"), \
 							span_danger("[M.name] bites you!"), span_hear("I hear a chomp!"), COMBAT_MESSAGE_RANGE, M)
 			to_chat(M, span_danger("I bite [src]!"))


### PR DESCRIPTION
## About The Pull Request

Гноллы (и не только) могли в инвизе спокойно кусать и пинать. Это не раскрывало их невидимость. Теперь раскрывает.

## Testing Evidence

>   <img width="219" height="249" alt="image" src="https://github.com/user-attachments/assets/a684a1b1-1568-48b9-88d6-fe49843feda2" />
> 
>   
> <img width="318" height="301" alt="image" src="https://github.com/user-attachments/assets/a4c4ceef-eb82-47b7-b92b-c9f761f24dac" />
> 
> 
> <img width="250" height="28" alt="image" src="https://github.com/user-attachments/assets/1ea48a76-3e62-4522-afe8-efcd17d8c0ab" />
> 
> <img width="315" height="321" alt="image" src="https://github.com/user-attachments/assets/2dbe71ef-b6df-4166-952b-f455c77fca9b" />


## Why It's Good For The Game

Огромные фурри качки теперь не могут делать кусь в полной невидимости

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Теперь пинки и укусы раскрывают невидимость
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
