### PR TITLE
Advance fix

### DIFF
--- a/code/modules/spells/spell_types/classunique/spellblade/advance.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/advance.dm
@@ -102,7 +102,8 @@
 		if(blocked)
 			break
 
-		step(H, facing)
+		if(!step(H, facing))
+			break
 		steps_taken++
 
 		if(i < leap_range)
@@ -115,6 +116,10 @@
 
 	H.pass_flags = old_pass
 	H.throwing = old_throwing
+
+	var/turf/landing_turf = get_turf(H)
+	if(landing_turf?.zFall(H))
+		return TRUE
 
 	if(steps_taken == 0)
 		to_chat(H, span_warning("My leap is blocked!"))


### PR DESCRIPTION
## About The Pull Request

Спеллблейд мог телепортироваться в воздух и там стоять, не падая. Теперь спеллблейд при попытке прыгнуть в опен спейс прыгает прямо вниз в канаву

## Testing Evidence

<img width="479" height="419" alt="image" src="https://github.com/user-attachments/assets/901d5388-e38d-47c9-9ca5-6248dd5c5842" />

<img width="309" height="123" alt="image" src="https://github.com/user-attachments/assets/08e1440c-a5a7-4dff-a18f-116e9b4e0911" />

<img width="426" height="441" alt="image" src="https://github.com/user-attachments/assets/ed58d820-223a-4b94-a7ff-057903791fc8" />

## Why It's Good For The Game

Спеллблейды теперь больше не маги воздуха из аватара

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Исправлена возможность для спеллблейдов оставаться в воздухе с помощью Advance!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
