### PR TITLE
[mod] Baota Nyke

### DIFF
--- a/modular_twilight_axis/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/modular_twilight_axis/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -33,30 +33,39 @@
 
 /proc/bountychoice_heretic(mob/living/carbon/human/H)
 	var/crimes = list("I'm nobody", "They fear me")
-	var/crimeschoice = input(H, "Who is me", "How much have I done?") as anything in crimes
-	switch(crimeschoice)
-		if("I'm nobody")
-			GLOB.excommunicated_players += H.real_name
-		if("They fear me")
-			if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
-				H.put_in_hands(new /obj/item/clothing/head/roguetown/helmet/blacksteel/psythorns)
-			wretch_select_bounty(H)
-			H.change_stat(STATKEY_WIL, 2)
-			H.change_stat(STATKEY_CON, 1)
+	if(H.patron?.type == /datum/patron/inhumen/baotha)
+		H.change_stat(STATKEY_WIL, -1)
+		to_chat(H, span_purple("'Я менял свой образ так много раз, что сам уже не помню кем я был....'"))
+		return
+	else
+		var/crimeschoice = input(H, "Who is me", "How much have I done?") as anything in crimes
+		switch(crimeschoice)
+			if("I'm nobody")
+				GLOB.excommunicated_players += H.real_name
+			if("They fear me")
+				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
+					H.put_in_hands(new /obj/item/clothing/head/roguetown/helmet/blacksteel/psythorns)
+				wretch_select_bounty(H)
+				H.change_stat(STATKEY_WIL, 2)
+				H.change_stat(STATKEY_CON, 1)
 
 /proc/bountychoice_hereticspy(mob/living/carbon/human/H)
 	var/crimes = list("I'm nobody", "They fear me")
-	var/crimeschoice = input(H, "Who is me", "How much have I done?") as anything in crimes
-	switch(crimeschoice)
-		if("I'm nobody")
-			GLOB.excommunicated_players += H.real_name
-		if("They fear me")
-			if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
-				H.put_in_hands(new /obj/item/clothing/mask/rogue/spectacles/inq)
-				H.put_in_hands(new /obj/item/grapplinghook)
-			wretch_select_bounty(H)
-			H.change_stat(STATKEY_SPD, 1)
-			H.change_stat(STATKEY_INT, 1)
+	if(H.patron?.type == /datum/patron/inhumen/baotha)
+		H.change_stat(STATKEY_SPD, -1)
+		to_chat(H, span_purple("'Я менял свой образ так много раз, что сам уже не помню кем я был....'"))
+	else
+		var/crimeschoice = input(H, "Who is me", "How much have I done?") as anything in crimes
+		switch(crimeschoice)
+			if("I'm nobody")
+				GLOB.excommunicated_players += H.real_name
+			if("They fear me")
+				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
+					H.put_in_hands(new /obj/item/clothing/mask/rogue/spectacles/inq)
+					H.put_in_hands(new /obj/item/grapplinghook)
+				wretch_select_bounty(H)
+				H.change_stat(STATKEY_SPD, 1)
+				H.change_stat(STATKEY_INT, 1)
 
 /proc/bountychoice_vigilante(mob/living/carbon/human/H)
 	var/crimes = list("I'm nobody", "They fear me")


### PR DESCRIPTION
## About The Pull Request

Модифицирую собственную систему под реалии новых мираклов шлюхи. После того как появился миракл смена образа у Баоты, люди это абузили просто беря розыск, лутая 11 поинтов статов, а следом меняли внешку по дескрипторам. Пора этому прекратиться.

# Изменения:

Еретику и Еретику шпиону был срезан розыск полностью, НО, так же были срезаны и статы. -1 вилка или -1 спида, делая их статпак на уровне чурок

## Testing Evidence

Было дело

## Why It's Good For The Game

Механики не должны абузиться для избежания кор геймплея роли, это во-первых. Во-вторых, теперь как на старом ТФе они смогу, наверно, отыгрывать. Не ебу как дальше это будут абузить.

## Changelog

:cl:

balance: stat bonus for Baota wretch deleted

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
