### PR TITLE
Фикс отображения сообщения в тикете после символа ":" 

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -1021,18 +1021,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			// Player message
 			msg_data["is_admin"] = FALSE
 			msg_data["author"] = initiator_key_name
-			// Extract the actual message after the last ": "
-			var/last_colon = 0
-			var/search_pos = 1
-			while(TRUE)
-				var/pos = findtext(clean_text, ": ", search_pos)
-				if(pos)
-					last_colon = pos
-					search_pos = pos + 1
-				else
-					break
-			if(last_colon)
-				msg_data["message"] = trim(copytext(clean_text, last_colon + 2))
+			// TA EDIT, extract the actual message after the first ": "
+			var/first_colon = findtext(clean_text, ": ")
+			if(first_colon)
+				msg_data["message"] = trim(copytext(clean_text, first_colon + 2))
 			else
 				msg_data["message"] = trim(clean_text)
 		else if(findtext(rest, "<font color='blue'>") || findtext(rest, "PM from"))
@@ -1045,18 +1037,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 				var/name_end = findtext(clean_text, ":", name_start)
 				if(name_end)
 					msg_data["author"] = trim(copytext(clean_text, name_start, name_end))
-			// Extract the actual message after the last ": "
-			var/last_colon = 0
-			var/search_pos = 1
-			while(TRUE)
-				var/pos = findtext(clean_text, ": ", search_pos)
-				if(pos)
-					last_colon = pos
-					search_pos = pos + 1
-				else
-					break
-			if(last_colon)
-				msg_data["message"] = trim(copytext(clean_text, last_colon + 2))
+			// TA EDIT, extract the actual message after the first ": "
+			var/first_colon = findtext(clean_text, ": ")
+			if(first_colon)
+				msg_data["message"] = trim(copytext(clean_text, first_colon + 2))
 			else
 				msg_data["message"] = trim(clean_text)
 		else if(findtext(rest, "<font color='green'>"))


### PR DESCRIPTION
## About The Pull Request
ПР фиксит назойливый баг, при котором часть сообщения до символа ":" при отправке в тикет-панель попросту обрезается из-за неверной генерации данных для ТГУИ.
## Testing Evidence
БЫЛО:
<img width="224" height="189" alt="UC9Tv2leTB" src="https://github.com/user-attachments/assets/46752b06-8d5e-4f9b-9b30-5fd78bbde4c2" />

СТАЛО:
<img width="289" height="129" alt="K0XOeJxjN0" src="https://github.com/user-attachments/assets/df8fc27c-d138-47a2-bd9a-01bd7f1c2a73" />
## Why It's Good For The Game
Фиксы багов - хорошо.
## Changelog
:cl:

fix: Исправлено отображение сообщений в тикете.

/:cl: