### PR TITLE
Timer fix

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -391,8 +391,6 @@ SUBSYSTEM_DEF(timer)
 /datum/timedevent/New(datum/callback/callBack, wait, flags, datum/controller/subsystem/timer/timer_subsystem, hash, source)
 	// TA EDIT START
 	if(isnull(callBack))
-		src.timer_subsystem = timer_subsystem || SStimer
-		spent = world.time || TRUE
 		return
 	// TA EDIT END
 	var/static/nextid = 1

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -389,6 +389,10 @@ SUBSYSTEM_DEF(timer)
 	var/bucket_pos = -1
 
 /datum/timedevent/New(datum/callback/callBack, wait, flags, datum/controller/subsystem/timer/timer_subsystem, hash, source)
+	// TA EDIT START
+	if(isnull(callBack))
+		return
+	// TA EDIT END
 	var/static/nextid = 1
 	id = TIMER_ID_NULL
 	src.callBack = callBack

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -391,6 +391,8 @@ SUBSYSTEM_DEF(timer)
 /datum/timedevent/New(datum/callback/callBack, wait, flags, datum/controller/subsystem/timer/timer_subsystem, hash, source)
 	// TA EDIT START
 	if(isnull(callBack))
+		src.timer_subsystem = timer_subsystem || SStimer
+		spent = world.time || TRUE
 		return
 	// TA EDIT END
 	var/static/nextid = 1


### PR DESCRIPTION
## About The Pull Request

«десериализация может создать таймер в обход инвариантов addtimer
savefile фактически сказал: “создай таймер”, но без callback, wait, flags и subsystem ->  поломка SStimer.

[21:44:20] Runtime in code/controllers/subsystem/timer.dm,417: Cannot read null.head_offset
  proc name: New (/datum/timedevent/New)
  src: Event not filled (/datum/timedevent)
  call stack:
  Event not filled (/datum/timedevent): New(null, null, null, null, null, null)
  /datum/preferences (/datum/preferences):  load virtue(data/player_saves/m/(COOLNAME)/pr... (/savefile))
  /datum/preferences (/datum/preferences): load character(10)
  /datum/preferences (/datum/preferences): New((COOLNAME) (/client))
  (COOLNAME) (/client): New(null)
  (COOLNAME) (/client): New()


Если чо, это костыль:
Правильный root fix: сохранять virtue.type, virtuetwo.type и отдельно простые списки picked_choices, а при загрузке принимать только /datum/virtue paths и валидировать старые сохраненные datum’ы как legacy input.
## Testing Evidence

Вроде робит

## Why It's Good For The Game

Фиксит вирус
