### PR TITLE
[FIX] Куртка инквизиции не защищает ладони

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -244,7 +244,7 @@
 	color = null
 	armor = ARMOR_PADDED
 	shiftable = FALSE
-	body_parts_covered = COVERAGE_ALL_BUT_LEGS
+	body_parts_covered = COVERAGE_ALL_BUT_HANDFEET //TA_EDIT
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/shadowrobe
 	name = "stalker robe"


### PR DESCRIPTION
## About The Pull Request
Убирает защиту кистей от рескина гамбезона для инквизиции, делает защиту аналогичной другим гамбезонам добавляя защиту LEGS.

## Testing Evidence
<img width="769" height="189" alt="image" src="https://github.com/user-attachments/assets/4c8ea430-4262-480f-b920-ccf7a3d7e324" />

## Why It's Good For The Game
Невидимая защита это плохо, невидимой защиты должно быть меньше.

## Changelog
:cl:
fix: inquisitorial leather tunic больше не защищает HAND, но получает защиту LEGS как у других гамбезонов.
/:cl: