### PR TITLE
Изменение кольца баоты и амулета зизо

### DIFF
--- a/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/thingsforcult.dm
+++ b/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/thingsforcult.dm
@@ -522,9 +522,9 @@ GLOBAL_DATUM_INIT(html_tags, /regex, regex(@"<.*?>", "g"))
 	mob_overlay_icon = 'modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/sprites/clothes/on_mob/zcross.dmi'
 	icon = 'modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/sprites/clothes/zcross.dmi'
 	icon_state = "zcross"
-	slot_flags = ITEM_SLOT_RING
+	slot_flags = ITEM_SLOT_NECK
 	sellprice = 0
-	max_integrity = 180
+	max_integrity = 160
 	body_parts_covered = COVERAGE_FULL | COVERAGE_HEAD_NOSE | NECK | HANDS | FEET 
 	armor = ARMOR_CULTNECK 
 	blade_dulling = DULLING_BASHCHOP

--- a/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/thingsforcult.dm
+++ b/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/thingsforcult.dm
@@ -522,9 +522,9 @@ GLOBAL_DATUM_INIT(html_tags, /regex, regex(@"<.*?>", "g"))
 	mob_overlay_icon = 'modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/sprites/clothes/on_mob/zcross.dmi'
 	icon = 'modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/sprites/clothes/zcross.dmi'
 	icon_state = "zcross"
-	slot_flags = ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_RING
 	sellprice = 0
-	max_integrity = 160
+	max_integrity = 180
 	body_parts_covered = COVERAGE_FULL | COVERAGE_HEAD_NOSE | NECK | HANDS | FEET 
 	armor = ARMOR_CULTNECK 
 	blade_dulling = DULLING_BASHCHOP

--- a/modular_twilight_axis/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/modular_twilight_axis/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -479,12 +479,10 @@
 
 /datum/status_effect/buff/griefflowerta/on_apply()
 	. = ..()
-	to_chat(owner, span_notice("The rosa’s flower ring draws blood from your finger, but you start feelings more pleasant."))
 	ADD_TRAIT(owner, TRAIT_CRACKHEAD, src)
 
 /datum/status_effect/buff/griefflowerta/on_remove()
 	. = ..()
-	to_chat(owner, span_notice("You part from the rosa-flower ring. The pleasant retreats..."))
 	REMOVE_TRAIT(owner, TRAIT_CRACKHEAD, src)
 
 /datum/status_effect/buff/griefflowerta/buff

--- a/modular_twilight_axis/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/modular_twilight_axis/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -443,23 +443,53 @@
 	return FALSE
 
 /obj/item/clothing/ring/TAgriefflower
-	name = "rosa ring"
-	desc = "Once a flower of love, now touched by Baotha's hand. Its petals whisper of desire, despair, and the kind of longing that never dies. Worn by those who cannot let go."
+	name = "flower ring"
+	desc = "A ring, which made by rosa buds."
 	icon_state = "peaceflower"
 	item_state = "peaceflower"
 	icon = 'icons/roguetown/items/produce.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/head_items.dmi'
 
+/obj/item/clothing/ring/TAgriefflower/examine(var/mob/living/carbon/human/user)
+	. = ..()
+	if(iscarbon(user))
+		if(user.patron.type == /datum/patron/inhumen/baotha)
+			. += ("Once a flower of love, now touched by Baotha's hand. Its petals whisper of desire, despair, and the kind of longing that never dies. Worn by those who cannot let go.")
+		if(user.patron.type == /datum/patron/divine/eora)
+			. += ("I can feel a strange energy from this ring... This is definitely not a ring created by just rosa buds. The energy of Baotha is felt from this ring.")
+
 /obj/item/clothing/ring/TAgriefflower/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
-	if(slot == SLOT_RING)
-		user.apply_status_effect(/datum/status_effect/buff/griefflower)
+	if(slot == SLOT_RING && user.patron?.type != /datum/patron/inhumen/baotha)
+		user.apply_status_effect(/datum/status_effect/buff/griefflowerta)
+		user.blood_volume = max(user.blood_volume-40, 0)
+		user.adjustBruteLoss(20)
+		to_chat(user, span_warning("AGH!... This flowers is hurting.. Ogh, i put it on carelessly and got hurt!"))
+	else if(slot == SLOT_RING && user.patron?.type == /datum/patron/inhumen/baotha)
+		user.apply_status_effect(/datum/status_effect/buff/griefflowerta/buff)
+		to_chat(user, span_notice("I follower of Baotha! Ring is accept me and wanst hurt me.."))
 
 /obj/item/clothing/ring/TAgriefflower/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(istype(user) && user?.wear_ring == src)
-		user.remove_status_effect(/datum/status_effect/buff/griefflower)
+		user.remove_status_effect(/datum/status_effect/buff/griefflowerta)
 
+/datum/status_effect/buff/griefflowerta
+	id = "griefflower"
+
+/datum/status_effect/buff/griefflowerta/on_apply()
+	. = ..()
+	to_chat(owner, span_notice("The rosa’s flower ring draws blood from your finger, but you start feelings more pleasant."))
+	ADD_TRAIT(owner, TRAIT_CRACKHEAD, src)
+
+/datum/status_effect/buff/griefflowerta/on_remove()
+	. = ..()
+	to_chat(owner, span_notice("You part from the rosa-flower ring. The pleasant retreats..."))
+	REMOVE_TRAIT(owner, TRAIT_CRACKHEAD, src)
+
+/datum/status_effect/buff/griefflowerta/buff
+	effectedstats = list(STATKEY_CON = 1,STATKEY_WIL = 1)
+	alert_type = /atom/movable/screen/alert/status_effect/buff/griefflower
 // Insufflation - effectively just drugging yourself. Lets you pick, the same as Enrapturing Powder. T1, for now, to make up for the loss of the Baotha Blessing buff.
 
 /obj/effect/proc_holder/spell/self/TAinsufflation 

--- a/modular_twilight_axis/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/modular_twilight_axis/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -452,11 +452,12 @@
 
 /obj/item/clothing/ring/TAgriefflower/examine(var/mob/living/carbon/human/user)
 	. = ..()
-	if(iscarbon(user))
-		if(user.patron.type == /datum/patron/inhumen/baotha)
-			. += ("Once a flower of love, now touched by Baotha's hand. Its petals whisper of desire, despair, and the kind of longing that never dies. Worn by those who cannot let go.")
-		if(user.patron.type == /datum/patron/divine/eora)
-			. += ("I can feel a strange energy from this ring... This is definitely not a ring created by just rosa buds. The energy of Baotha is felt from this ring.")
+	if(!iscarbon(user) || !user.patron)
+		return
+	if(user.patron.type == /datum/patron/inhumen/baotha)
+		. += ("Once a flower of love, now touched by Baotha's hand. Its petals whisper of desire, despair, and the kind of longing that never dies. Worn by those who cannot let go.")
+	if(user.patron.type == /datum/patron/divine/eora)
+		. += ("I can feel a strange energy from this ring... This is definitely not a ring created by just rosa buds. The energy of Baotha is felt from this ring.")
 
 /obj/item/clothing/ring/TAgriefflower/equipped(mob/living/carbon/human/user, slot)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Более разумное решение "проблемы", кое было в [другом пре](https://github.com/Twilight-Fortress-SS13/Twilight-Axis/pull/1148)
Кольцо баоты:
-Изменено его название и описание. Теперь по-сути это просто цветочное кольцо. Последователи баоты видят дополнительное описание, а последователи эоры понимают, что это не просто цветочное кольцо.
-Убран бафф статов для НЕ баотистов, а также статус-алерт. Теперь НЕ баотистам не высвечивается сверху бафф кольца.
-Если его надевает НЕ баотист, то тот получает -40 крови и немного урона. В чат высвечивается что "надел не аккуратно".
-Алерт об баффе высвечивается только баотистам.

Амулет зизо:
-Теперь его можно надеть только на слот кольца. 
-Добавил +20 интегры.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="1262" height="971" alt="NVIDIA_Overlay_fIrpmKZRx5" src="https://github.com/user-attachments/assets/e94eadc9-3ef0-4d6a-90ed-13c581d7e020" />
<img width="1108" height="599" alt="NVIDIA_Overlay_HEwd7kbtGE" src="https://github.com/user-attachments/assets/be43f6d3-2e5c-4c05-9a29-9e74c0c1372f" />
<img width="1161" height="846" alt="NVIDIA_Overlay_AEbsn6EnO5" src="https://github.com/user-attachments/assets/b6a8fa68-3919-4ef5-a4cd-229ac7ba14f2" />
<img width="1902" height="1062" alt="NVIDIA_Overlay_I81IkifWvA" src="https://github.com/user-attachments/assets/2b70c144-f8d1-4c6d-9689-1946de165d2b" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
-Амулет зизо более юзабелен
-Меньше "меты" на кольцо. Теперь оно логично замаскированно.
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: 
-Амулет зизо теперь надевается на слот кольца, а не шеи.
balance:
Кольцо баоты:
-Изменено его название и описание. Теперь по-сути это просто цветочное кольцо. Последователи баоты видят дополнительное описание, а последователи эоры понимают, что это не просто цветочное кольцо.
-Убран бафф статов для НЕ баотистов, а также статус-алерт. Теперь НЕ баотистам не высвечивается сверху бафф кольца.
-Если его надевает НЕ баотист, то тот получает -40 крови и немного урона. В чат высвечивается что "надел не аккуратно".
-Алерт об баффе высвечивается только баотистам.

Амулет зизо:
-Добавлено +20 прочности к амулету.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
