### PR TITLE
Фикс стелс трупов

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -94,6 +94,7 @@ GLOBAL_LIST_EMPTY(last_words)
 		record_round_statistic(blood_toll_bucket)
 	set_stat(DEAD)
 	unset_machine()
+	stop_sneaking_on_death()
 	timeofdeath = world.time
 	tod = station_time_timestamp()
 //	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -45,6 +45,24 @@
 /mob/living/update_sneak_invis()
 	if(m_intent = MOVE_INTENT_SNEAK)
 */
+
+/mob/living/proc/stop_sneaking_on_death()
+	if(m_intent != MOVE_INTENT_SNEAK && !rogue_sneaking)
+		return
+
+	m_intent = MOVE_INTENT_WALK
+
+	if(rogue_sneaking)
+		animate(src, alpha = initial(alpha), time = 0)
+		alpha = initial(alpha)
+		regenerate_icons()
+		rogue_sneaking = FALSE
+		SEND_SIGNAL(src, COMSIG_MOB_BREAK_SNEAK)
+
+	if(hud_used?.static_inventory)
+		for(var/atom/movable/screen/rogmove/selector in hud_used.static_inventory)
+			selector.update_icon()
+
 /mob/living/def_intent_change()
 	. = ..()
 	update_move_intent_slowdown()


### PR DESCRIPTION
## About The Pull Request

Теперь, когда кто то умирает, то у него насильно отрубается стелс. чтобы труп не был скрытным.
По багрепорту: https://discord.com/channels/1133928966915358822/1515798264275013682
## Testing Evidence

Дюран дюран

## Why It's Good For The Game

Трупы больше не могут в стелс

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: исправлен недочет с тем, что смерть не убирала стелс
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
