### PR TITLE
[БАГ] Исправление возможности выставить рипост после финта

### DIFF
--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -232,7 +232,7 @@
 	if(is_swinging(disrupt_only = TRUE))
 		return FALSE
 
-	if(has_status_effect(/datum/status_effect/debuff/exposed))
+	if(has_status_effect(/datum/status_effect/debuff/exposed) || has_status_effect(/datum/status_effect/debuff/vulnerable))
 		return FALSE
 
 	if(get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(src, TRAIT_LIGHT_STEP))

--- a/code/modules/mob/living/combat/checkdefense.dm
+++ b/code/modules/mob/living/combat/checkdefense.dm
@@ -42,6 +42,8 @@
 			CAR.adjust_arousal_special(src, 2)
 
 	if(has_status_effect(/datum/status_effect/debuff/vulnerable))
+		remove_status_effect(/datum/status_effect/buff/clash)
+		remove_status_effect(/datum/status_effect/buff/clash/limbguard)
 		if(!has_status_effect(/datum/status_effect/buff/weapon_binded) && !has_status_effect(/datum/status_effect/debuff/weapon_binded))
 			if(ishuman(src) && user.get_tempo_bonus(TEMPO_TAG_BINDABLE) && mind && user?.mind)
 				var/held = get_active_held_item()
@@ -51,6 +53,7 @@
 						if(HL.try_bind(held, user, TRUE))
 							remove_status_effect(/datum/status_effect/debuff/vulnerable)
 							return TRUE
+		return FALSE
 
 		// TA Edit start - SOUNDBREAKER
 	var/success = FALSE

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -888,7 +888,7 @@ SPECIALS START HERE
 
 //apply_cost is called before anything else, so it works here for the toggle checks, but it's kind of a bad example -- don't do this.
 /datum/special_intent/limbguard/apply_cost(mob/living/L)
-	if(L.has_status_effect(/datum/status_effect/buff/clash) || L.toggle_timer > world.time)
+	if(L.has_status_effect(/datum/status_effect/buff/clash) || L.has_status_effect(/datum/status_effect/debuff/vulnerable) || L.toggle_timer > world.time)
 		return FALSE
 	var/datum/status_effect/buff/clash/limbguard/lg = L.has_status_effect(/datum/status_effect/buff/clash/limbguard)
 	if(lg)


### PR DESCRIPTION
## About The Pull Request

Этот ПР исправляет абуз, при котором игрок под эффектом уязвимости от финта мог быстро выключить и снова включить комбат мода, после чего выставить защитную стойку и защититься от последующего удара.

Оно так не должно было работать.

## Testing Evidence

Ну оно должно работать

## Why It's Good For The Game

Абуз раковых штук это плохо

## Changelog

:cl:
fix: Исправлена возможность обходить уязвимость от финта через переключение комбат мода
/:cl:
