### PR TITLE
Нерф АП у АОЕ оборотней

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -254,7 +254,7 @@
 	parrysound = list('sound/combat/parry/parrygen.ogg')
 	embedding = list("embedded_pain_multiplier" = 0, "embed_chance" = 0, "embedded_fall_chance" = 0)
 	item_flags = DROPDEL
-	special = /datum/special_intent/axe_swing/graggarite	//Good pairing for area denial for WW's.
+	special = /datum/special_intent/axe_swing/graggarite/werewolf	//Good pairing for area denial for WW's. // TA EDIT
 	experimental_inhand = FALSE
 
 /obj/item/rogueweapon/werewolf_claw/right

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -16,6 +16,8 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 	var/mob/living/howner
 	var/atom/movable/iparent
 
+	var/special_armor_penetration = null // TA EDIT
+
 	/// The main place where we can draw out the pattern. Every tile entry is a list with two numbers.
 	/// The origin (0,0) is one step forward from the dir the owner is facing.
 	/// This is abstract, and can be modified, though it's best done before _assign_grid_indexes().
@@ -362,7 +364,10 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 	if(ishuman(target))
 		var/mob/living/carbon/human/HT = target
 		var/obj/item/bodypart/affecting = HT.get_bodypart(zone)
-		var/armor_block = HT.run_armor_check(zone, d_type, 0, damage = dam, used_weapon = W, armor_penetration = (no_pen ? PEN_NONE : 0))
+		var/armor_penetration = no_pen ? PEN_NONE : 0 // TA EDIT START
+		if(!isnull(special_armor_penetration))
+			armor_penetration = special_armor_penetration
+		var/armor_block = HT.run_armor_check(zone, d_type, 0, damage = dam, used_weapon = W, armor_penetration = armor_penetration) // TA EDIT END
 		if(full_pen)
 			armor_block = 0		//You block NOTHING, sir!
 		if(HT.apply_damage(dam, W.damtype, affecting, armor_block))
@@ -701,6 +706,9 @@ SPECIALS START HERE
 
 /datum/special_intent/axe_swing/graggarite
 	requires_wielding = FALSE
+
+/datum/special_intent/axe_swing/graggarite/werewolf // TA EDIT
+	special_armor_penetration = PEN_MEDIUM // TA EDIT
 
 #undef AXE_SWING_GRID_DEFAULT
 #undef AXE_SWING_GRID_MIRROR


### PR DESCRIPTION
## About The Pull Request

Ослабляет пробитие брони у АОЕ-атаки оборотня Hefty Swing.
АП у этой способности скейлилось слишком сильно. Очень странно, что АОЕ способность прошивает абсолютно все.

По предложке: https://discord.com/channels/1133928966915358822/1518989136948629704

## Testing Evidence

Работает

## Why It's Good For The Game

Hefty Swing у оборотня был слишком эффективен против бронированных целей, особенно с учётом того, что атака работает по площади.
Если оборотни станут после этого намного слабее, то откачу/переделаю
## Changelog

:cl:
balance: Ослаблено пробитие брони у АОЕ-атаки оборотня Hefty Swing.
/:cl:

