### PR TITLE
Новый var/silver_weak у брони

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -207,6 +207,7 @@
 	item_flags = DROPDEL
 	repair_time = 15 SECONDS
 	interrupt_damount = 35
+	silver_weak = TRUE
 
 /datum/intent/simple/werewolf
 	name = "claw"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -60,6 +60,8 @@
 	var/chunkcolor = "#5e5e5e"
 	var/material_category = ARMOR_MAT_LEATHER
 	var/throw_on_break = FALSE
+	var/silver_weak = FALSE
+	var/silver_weak_damage_multiplier = 1.4
 
 /obj/item
 	var/blocking_behavior

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -14,6 +14,15 @@
 	return (armorval/max(organnum, 1))
 
 
+/mob/living/carbon/human/proc/apply_silver_weak_armor_damage_bonus(obj/item/clothing/armor_piece, obj/item/used_weapon, armor_damage)
+	if(!armor_damage)
+		return armor_damage
+	if(!armor_piece?.silver_weak)
+		return armor_damage
+	if(!istype(used_weapon) || !used_weapon.is_silver)
+		return armor_damage
+	return round(armor_damage * armor_piece.silver_weak_damage_multiplier)
+
 /mob/living/carbon/human/proc/checkarmor(def_zone, d_type, damage, armor_penetration = PEN_NONE, blade_dulling, intdamfactor = 1, obj/item/used_weapon, pen_info)
 	if(!d_type)
 		return 0
@@ -83,6 +92,7 @@
 					remove_status_effect(/datum/status_effect/debuff/vulnerable)
 					emote("groan", forced = TRUE)
 
+			intdamage = apply_silver_weak_armor_damage_bonus(used, used_weapon, intdamage)
 			used.take_damage(intdamage, damage_flag = d_type, sound_effect = FALSE, armor_penetration = 100)
 	else
 		// DR types: blunt, fire, acid
@@ -130,6 +140,7 @@
 				var/actualdmg = intdamage
 				if(!full_dmg)
 					actualdmg /= layers_deep
+				actualdmg = apply_silver_weak_armor_damage_bonus(C, used_weapon, actualdmg)
 				C.take_damage(actualdmg, damage_flag = d_type, sound_effect = FALSE, armor_penetration = 100)
 				if(C.blocksound && !played_sound)
 					playsound(loc, get_armor_sound(C.blocksound, blade_dulling), 100)


### PR DESCRIPTION
## About The Pull Request

Возможность сделать броню уязвимой к серебряному оружию. В этом ПРе пока что лишь у оборотней сделано. Их шкура будет получать на 40% больше урона от серебра (цифру можно также изменить у каждой брони индивидуально)

## Testing Evidence

Оно работает

## Why It's Good For The Game

Пока не знаю, надо оно или не надо. В ТМ моментально кидать не буду, подумаю еще

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Возможность сделать броню уязвимой к серебру
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
