### PR TITLE
Потребление стамины для перезарядки у рунлоков и убирание дыма

### DIFF
--- a/modular_twilight_axis/firearms/code/weapons/ammo_holders.dm
+++ b/modular_twilight_axis/firearms/code/weapons/ammo_holders.dm
@@ -166,7 +166,7 @@
 /obj/item/quiver/twilight_bullet/runicbag/attack_self(mob/living/user)
 	if(linked_ammo_types)
 		to_chat(user, span_notice("I begin recalling my ammunition..."))
-		if(do_after(user, 10 SECONDS, src))
+		if(do_after(user, 15 SECONDS, src))
 			playsound(src, 'sound/magic/blink.ogg', 80)
 			for(var/B in linked_ammo_types)
 				if(arrows.len < max_storage)

--- a/modular_twilight_axis/firearms/code/weapons/runelock.dm
+++ b/modular_twilight_axis/firearms/code/weapons/runelock.dm
@@ -25,6 +25,7 @@
 	var/misfire_chance = 0
 	/// Reload time, in SECONDS
 	var/reload_time = 8
+	var/reload_stamina_cost = 15
 	damfactor = 1
 	var/critfactor = 0.7
 	var/npcdamfactor = 4
@@ -62,6 +63,7 @@
 					if(skill)
 						adj_reload_time = reload_time / skill
 				if(move_after(H, adj_reload_time SECONDS, target = H))
+					H.stamina_add(reload_stamina_cost)
 					playsound(H, 'modular_twilight_axis/firearms/sound/musketcock.ogg', 100, FALSE)
 					cocked = TRUE
 			else
@@ -165,7 +167,7 @@
 		spread = max(3, spread / skill)
 	if(prob(misfire_chance))
 		to_chat(user, span_warning("The [name] misfires!"))
-		explosion(src, light_impact_range = 2, heavy_impact_range = 1, smoke = TRUE, soundin = 'sound/misc/explode/bomb.ogg')
+		explosion(src, light_impact_range = 2, heavy_impact_range = 1, smoke = FALSE, soundin = 'sound/misc/explode/bomb.ogg')
 		qdel(src)
 		return
 	for(var/obj/item/ammo_casing/CB in get_ammo_list(FALSE, TRUE))
@@ -176,10 +178,6 @@
 		BB.damage *= damfactor * per_scaling
 	cocked = FALSE
 	update_icon()
-	var/dir = get_dir(src, target)
-	var/datum/effect_system/smoke_spread/smoke = new
-	smoke.set_up(1, get_step(src, dir))
-	smoke.start()
 	..()
 
 /obj/item/ammo_box/magazine/internal/shot/twilight_runelock
@@ -251,6 +249,7 @@
 	damfactor = 1.5
 	critfactor = 1
 	reload_time = 12
+	reload_stamina_cost = 20
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/twilight_runelock/rifle/getonmobprop(tag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

У рунлоков не было цены за перезарядку, от чего ими можно было легко спамить. Теперь перебирание руками по рунам на оружии для отаванцев будет за счет их стамины. 

Также увеличил время сбора пуль от рунлока, чтобы было сложнее заниматься подобным в бою, и убрал дымовую завесу после выстрела с рунлока. По идеи, ее быть не должно, ибо рунлок не использует порох. Мне кажется так будет логичнее.

## Testing Evidence

<img width="558" height="660" alt="image" src="https://github.com/user-attachments/assets/43481870-30ca-4d45-b2fd-fb62394d8d70" />

## Why It's Good For The Game

Надеюсь, что так будет баланс. У меня нет в планах делать рунлоки слишком слабыми, но и хотелось бы сделать расплату за спам ими. Если это вдруг сильно ослабит инквизицию, то я переработаю цифры/уберу. Хотя не думаю, что так выйдет.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Теперь перезарядка рунлоков требует стамину, а их сбор сумкой увеличен
code: Убрана дымовая завеса после выстрелов с рунлока.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
