### PR TITLE
Грабнутый теперь не тратит стамину когда его тащат в воду

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -1,4 +1,10 @@
+#define WATER_PULLING_STAMINA_MULTIPLIER 1.5 // TA EDIT
+
 ///////////// OVERLAY EFFECTS /////////////
+
+/atom/movable // TA EDIT
+	var/tmp/water_dragged = FALSE // TA EDIT
+
 /obj/effect/overlay/water
 	icon = 'icons/turf/newwater.dmi'
 	icon_state = "bottom"
@@ -75,6 +81,8 @@
 						if(!locate(/mob/living) in src)
 							water_overlay.layer = BELOW_MOB_LAYER
 							water_overlay.plane = GAME_PLANE
+			if(user.water_dragged) // TA EDIT
+				return // TA EDIT
 			var/drained = get_stamina_drain(user, get_dir(src, newloc))
 			if(drained && !user.stamina_add(drained))
 				user.Immobilize(30)
@@ -130,6 +138,10 @@
 		for(var/D in GLOB.cardinals) //adjacent to a floor to hold onto
 			if(istype(get_step(src, D), /turf/open/floor))
 				return 0
+	if(.)
+		var/atom/movable/pulled = swimmer.pulling
+		if(!swimmer.moving_from_pull && pulled && pulled != swimmer && isliving(pulled))
+			. *= WATER_PULLING_STAMINA_MULTIPLIER
 
 // Mobs won't try to path through water if low on stamina,
 // and will take advantage of water flow to move faster.
@@ -655,3 +667,6 @@
 	swim_skill = TRUE
 	wash_in = TRUE
 	water_reagent = /datum/reagent/water/gross
+
+
+#undef WATER_PULLING_STAMINA_MULTIPLIER // TA EDIT

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1062,7 +1062,15 @@
 	if(pulling)
 		update_pull_movespeed()
 
+	var/atom/movable/water_dragged_atom // TA EDIT START
+	if(!moving_from_pull && pulling && pulling != src)
+		water_dragged_atom = pulling
+		water_dragged_atom.water_dragged = TRUE
+
 	. = ..()
+
+	if(water_dragged_atom && !QDELETED(water_dragged_atom))
+		water_dragged_atom.water_dragged = FALSE // TA EDIT END
 
 	update_sneak_invis()
 


### PR DESCRIPTION
## About The Pull Request

Люди очень любят абузить всякую херню, чтобы кого то победить в 2д игре. Сделал так, чтобы у того, кого тащат в воду, не тратило стамину, а то некоторые геймеры так убивают стамину своим жертвам.

## Testing Evidence

На локалке тестил, работает

## Why It's Good For The Game

Меньше раковых абузов это круто

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Теперь грабнутый не тратит стамину при перемещениях по тайлам воды
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
