### PR TITLE
Теперь меньше жрет синей полоски и меньше заточки

### DIFF
--- a/code/game/objects/items/rogueweapons/integrity.dm
+++ b/code/game/objects/items/rogueweapons/integrity.dm
@@ -1,3 +1,5 @@
+#define BLADE_INTEGRITY_LOSS_MULT 0.7 // TA EDIT
+
 /obj/item
 	/// Current blade integrity
 	var/blade_int = 0
@@ -15,6 +17,7 @@
 /obj/item/proc/remove_bintegrity(amt as num, mob/user)
 	if(sharpness == IS_BLUNT)
 		return FALSE
+	amt *= BLADE_INTEGRITY_LOSS_MULT // TA EDIT
 	if(sharpness_mod != 1)
 		amt *= sharpness_mod
 	if(cleave_sharpness_mult != 1)
@@ -136,3 +139,5 @@
 /obj/item/proc/restore_bintegrity()
 	max_blade_int = initial(max_blade_int)//Given it's reduced above.
 	blade_int = initial(max_blade_int)//Now return it.
+
+#undef BLADE_INTEGRITY_LOSS_MULT

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -99,7 +99,7 @@
 
 	return nutrition_amount
 
-/mob/living/stamina_add(added as num, emote_override, force_emote = TRUE) //call update_stamina here and set last_fatigued, return false when not enough fatigue left
+/mob/living/stamina_add(added as num, emote_override, force_emote = TRUE, energy_loss_mult = 0.6) // TA EDIT
 	if(HAS_TRAIT(src, TRAIT_INFINITE_STAMINA))
 		return TRUE
 
@@ -117,7 +117,7 @@
 
 	stamina = CLAMP(stamina+added, 0, max_stamina)
 	if(added > 0)
-		energy_add(added * -1)
+		energy_add(added * -energy_loss_mult) // TA EDIT
 		adjust_nutrition(-stamina_nutrition_mod(added))
 	if(added >= 5)
 		if(energy <= 0)
@@ -176,7 +176,7 @@
 		if(energy <= 0)
 			addtimer(CALLBACK(src, PROC_REF(Knockdown), 30), 1 SECONDS)
 			var/area/rogue/our_area = get_area(src)
-			if(our_area.necra_area)
+			if(our_area && our_area.necra_area) // TA EDIT
 				src.extract_from_deaths_edge()
 		addtimer(CALLBACK(src, PROC_REF(Immobilize), 30), 1 SECONDS)
 		if(iscarbon(src))

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -596,7 +596,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			var/mob/living/L = user
 			var/fatigue = calculate_fatigue_drain(L)
 			if(fatigue > 0)
-				L.stamina_add(fatigue)
+				L.stamina_add(fatigue, null, TRUE, 1) // TA EDIT
 		invocation(user)
 		start_recharge()
 		if(sound)
@@ -605,7 +605,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		if(isliving(user))
 			var/mob/living/L = user
 			if(releasedrain > 0)
-				L.stamina_add(calculate_fatigue_drain(L))
+				L.stamina_add(calculate_fatigue_drain(L), null, TRUE, 1) // TA EDIT
 			if(L.has_status_effect(/datum/status_effect/buff/clash))
 				var/mob/living/carbon/human/H = user
 				H.bad_guard(span_warning("I can't focus while casting spells!"), cheesy = TRUE)


### PR DESCRIPTION
## About The Pull Request

Реализовал идеи из этих двух ПРов:
https://github.com/Twilight-Fortress-SS13/Twilight-Axis/pull/1074
https://github.com/Twilight-Fortress-SS13/Twilight-Axis/pull/1072

Не перезаписывая прок, как в первом, что создало бы лишнюю головную боль при апдейтах, а также путаницу. И также не увеличиваю всему оружию заточку, а уменьшив трату заточки при ударах и парированиях на 30%

Расход синей полоски теперь меньше на 40% при совершении большинства действий, кроме заклинаний. Заклинания потребляют синюю полоску как и раньше. 

## Testing Evidence

Тестил на локалке, все работало.

## Why It's Good For The Game

Слышал жалобы на то, что синяя полоска слишком быстро улетает, а также сам замечал как быстро улетает заточка. Попробуем это решить таким способом.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Синяя полоска тратится на 40% меньше (исключение заклинания)
balance: Заточка тратится на 30% меньше
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
