### PR TITLE
фикс проскальзывания пустынных следов в другие карты

### DIFF
--- a/code/game/objects/effects/animal_hunting/animal_categories.dm
+++ b/code/game/objects/effects/animal_hunting/animal_categories.dm
@@ -187,3 +187,20 @@
 		/mob/living/simple_animal/hostile/retaliate/rogue/boar = "suidae"
 	)
 	preferred_areas = list()
+
+// TA EDIT START
+/datum/hunting_category/proc/can_spawn_in_area(area/A)
+	if(!A)
+		return FALSE
+	if(!preferred_areas || !preferred_areas.len)
+		return TRUE
+	return preferred_areas[A.type] > 0
+
+/datum/hunting_category/proc/get_area_bonus(area/A)
+	if(!A || !preferred_areas)
+		return 0
+	var/bonus = preferred_areas[A.type]
+	if(!bonus)
+		return 0
+	return bonus
+// TA EDIT END

--- a/code/game/objects/effects/animal_hunting/animal_maps.dm
+++ b/code/game/objects/effects/animal_hunting/animal_maps.dm
@@ -37,6 +37,12 @@
 		to_chat(user, span_warning("This trail has been cross-examined with a map for the best routes."))
 		return
 
+	var/datum/hunting_category/C = new target_category() // TA EDIT START
+	var/area/A = get_area(target)
+	if(!C.can_spawn_in_area(A))
+		to_chat(user, span_warning("The signs shown on [src] do not match this terrain."))
+		return // TA EDIT END
+
 	user.visible_message(span_notice("[user] consults [src] while examining the earth."), \
 		span_notice("You cross-reference the signs in the dirt with the markings on [src]..."))
 

--- a/code/game/objects/effects/animal_hunting/animal_tracks.dm
+++ b/code/game/objects/effects/animal_hunting/animal_tracks.dm
@@ -66,7 +66,9 @@
 	// Skill 5+ shows area efficiency
 	if(skill >= 5)
 		var/area/A = get_area(src)
-		var/bonus = hunt_category?.preferred_areas[A.type]
+		var/bonus = 0 // TA EDIT START
+		if(hunt_category)
+			bonus = hunt_category.get_area_bonus(A) // TA EDIT END
 		if(bonus)
 			. += "<br><details><summary><span class='nicegreen'>Environmental Analysis</span></summary>"
 			. += span_info("The local terrain ([A.name]) increases discovery chances by <b>[bonus]%</b>.")
@@ -87,7 +89,7 @@
 	// Find categories that actually like this specific area
 	for(var/cat_type in subtypesof(/datum/hunting_category))
 		var/datum/hunting_category/C = new cat_type()
-		if(C.preferred_areas[A.type] > 0)
+		if(C.can_spawn_in_area(A) && C.get_area_bonus(A) > 0) // TA EDIT
 			valid_cats[C.name] = C
 
 	if(!valid_cats.len)
@@ -382,14 +384,22 @@
 	var/list/cat_weights = list()
 
 	if(secret_map_influence)
-		hunt_category = new secret_map_influence()
-	else
+		var/datum/hunting_category/C = new secret_map_influence() // TA EDIT START
+		if(C.can_spawn_in_area(A))
+			hunt_category = C
+		else
+			secret_map_influence = null
+
+	if(!hunt_category)
 		for(var/cat_type in subtypesof(/datum/hunting_category))
 			var/datum/hunting_category/C = new cat_type()
+			if(!C.can_spawn_in_area(A))
+				continue
+
 			var/weight = C.skill_weights[skill + 1]
 
 			// Exact type matching for area bonus to avoid using subtypes
-			var/area_bonus = C.preferred_areas[A.type]
+			var/area_bonus = C.get_area_bonus(A) // TA EDIT END
 			if(area_bonus)
 				weight = max(0, weight * (1 + (area_bonus / 100)))
 


### PR DESCRIPTION
## About The Pull Request

На карты Рокхилла и Азура могли просочиться пустынные следы. Теперь не должны.
По баг-репорту: https://discord.com/channels/1133928966915358822/1519391850421686474

## Testing Evidence

Должно работать

## Why It's Good For The Game

Не будет следов пустынных животных в лесу Азура

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Фикс проскальзывания пустынных следов в другие карты
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
