### PR TITLE
Фиксы фамильяров и форм ведьмы

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -200,7 +200,7 @@
 	name = "Bat Form"
 	desc = ""
 	overlay_state = "bat_transform"
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/witch_shifted
 	knockout_on_death = 30 SECONDS
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/witch/crow
@@ -208,7 +208,7 @@
 	overlay_state = "zad"
 	desc = ""
 	knockout_on_death = 15 SECONDS
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow/witch_shifted
 	sound = 'sound/vo/mobs/bird/birdfly.ogg'
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/witch/lesser_vernard
@@ -229,6 +229,24 @@
 	overlay_state = "cabbit_transform"
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab/cabbit/witch_shifted
 
+/mob/living/simple_animal/hostile/retaliate/bat/witch_shifted
+	name = "bat"
+	desc = "A small fluttering creature. This one has a peculiar intelligence in its eyes..."
+	speed = 0
+	move_to_delay = 2
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
+	wander = FALSE
+
+/mob/living/simple_animal/hostile/retaliate/bat/crow/witch_shifted
+	name = "zad"
+	desc = "A black bird with a peculiar intelligence in its eyes..."
+	speed = 0
+	move_to_delay = 2
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
+	wander = FALSE
+
 /datum/intent/simple/claw/witch_cat
 	name = "scratch"
 	attack_verb = list("scratches", "claws")
@@ -236,6 +254,11 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/witch_shifted
 	name = "lesser volf"
 	desc = "A smaller, runtier variant of the classic volf that hounds the woods nearby. Rarely seen around these parts, and doesn't look nearly as dangerous as its larger counterparts. This one has a peculiar intelligence in its yellow eyes..."
+	speed = 0
+	move_to_delay = 2
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
+	wander = FALSE
 	STASPD = 15
 	STASTR = 3
 	STACON = 5
@@ -247,6 +270,11 @@
 /mob/living/simple_animal/pet/cat/witch_shifted
 	name = "aloof cat"
 	desc = "A bored-seeming feline. This one has a peculiar intelligence in its green eyes..."
+	speed = 0
+	move_to_delay = 2
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
+	wander = FALSE
 	defprob = 90
 	STASPD = 18
 	STASTR = 1
@@ -258,6 +286,11 @@
 /mob/living/simple_animal/pet/cat/rogue/black/witch_shifted
 	name = "voidblack cat"
 	desc = "Supposedly sacred to Necra, and just as interested in rats as their lesser counterparts. This one has a strange intelligence behind its dark, wide eyes..."
+	speed = 0
+	move_to_delay = 2
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
+	wander = FALSE
 	defprob = 90
 	STASPD = 18
 	STASTR = 1
@@ -269,6 +302,11 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/fox/witch_shifted
 	name = "lesser vernard"
 	desc = "A smaller, runtier variant of the sneaky vernards that skulk the woods nearby. Rarely seen around these parts, and doesn't look nearly as dangerous as its larger counterparts. This one has a peculiar intelligence in its yellow eyes..."
+	speed = 0
+	move_to_delay = 2
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
+	wander = FALSE
 	defprob = 90
 	STASPD = 18
 	STASTR = 2
@@ -281,6 +319,11 @@
 /mob/living/simple_animal/hostile/retaliate/smallrat/witch_shifted
 	name = "small rous"
 	desc = "Supposedly sacred to Pestra, these small and occasionally pestilent creachurs are commonly found in pantries and ships. This one seems to be a bit more smarter than the others..."
+	speed = 0
+	move_to_delay = 2
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
+	wander = FALSE
 	defprob = 90
 	STASPD = 18
 	STASTR = 1
@@ -292,6 +335,11 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab/cabbit/witch_shifted
 	name = "lesser cabbit"
 	desc = "Seeing one of these quick beasts is said to bring Xylix's fortune, along with their feet. It looks weak and innocent, and incredibly adorable."
+	speed = 0
+	move_to_delay = 2
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
+	wander = FALSE
 	defprob = 90
 	STASPD = 20
 	STASTR = 1

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -48,7 +48,8 @@
 	response_harm_continuous = "kicks"
 	response_harm_simple = "kick"
 	faction = list(FACTION_ROGUEANIMAL, FACTION_NEUTRAL)
-	speed = 0.8
+	speed = 0
+	move_to_delay = 2
 	breedchildren = 0 //Yeah no, I'm not falling for this one.
 	dodgetime = 20
 	held_items = list(null, null)

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -103,6 +103,41 @@
 	log_game("[key_name(user)] sent a message to [key_name(summoner)] with contents [message]")
 	return TRUE
 
+/mob/living/simple_animal/pet/familiar/proc/clear_familiar_click_intercepts()
+	if(ranged_ability)
+		ranged_ability.deactivate(src)
+
+	if(click_intercept)
+		if(istype(click_intercept, /datum/action/cooldown))
+			var/datum/action/cooldown/cooldown_action = click_intercept
+			cooldown_action.unset_click_ability(src, refund_cooldown = TRUE)
+		else if(istype(click_intercept, /obj/effect/proc_holder))
+			var/obj/effect/proc_holder/proc_holder = click_intercept
+			proc_holder.remove_ranged_ability()
+		else
+			click_intercept = null
+
+	if(client)
+		for(var/datum/action/cooldown/spell/spell_action as anything in actions)
+			spell_action.UnregisterSignal(client, list(COMSIG_CLIENT_MOUSEDOWN, COMSIG_CLIENT_MOUSEUP))
+		update_mouse_pointer()
+
+/mob/living/simple_animal/pet/familiar/proc/refresh_familiar_action_buttons(force_rebuild = FALSE)
+	if(!client || !hud_used)
+		return
+
+	for(var/datum/action/action as anything in actions.Copy())
+		var/atom/movable/screen/movable/action_button/button = action.viewers[hud_used]
+		if(force_rebuild || !button || QDELETED(button) || !(button in client.screen))
+			if(button && !QDELETED(button))
+				client.screen -= button
+				qdel(button)
+			action.viewers -= hud_used
+			action.ShowTo(src)
+		action.build_all_button_icons(ALL, TRUE)
+
+	update_action_buttons(TRUE)
+
 /datum/action/cooldown/spell/familiar_transform
 	name = "Spirit Transformation"
 	desc = "Draw your form into itself, becoming a small orb that is wearable as a pendant, or revert to your original form."
@@ -117,10 +152,22 @@
 	spell_requirements = NONE
 	spell_impact_intensity = SPELL_IMPACT_NONE
 
-/datum/action/cooldown/spell/familiar_transform/cast(mob/living/simple_animal/pet/familiar/user)
+/datum/action/cooldown/spell/familiar_transform/IsAvailable(feedback = FALSE)
+	var/mob/living/simple_animal/pet/familiar/user = owner
+	if(istype(user) && istype(user.loc, /obj/item/magic/familiar/familiar_spirit))
+		var/old_check_flags = check_flags
+		check_flags &= ~AB_CHECK_IMMOBILE
+		. = ..(feedback)
+		check_flags = old_check_flags
+		return
+	return ..(feedback)
+
+/datum/action/cooldown/spell/familiar_transform/cast(atom/cast_on)
 	. = ..()
+	var/mob/living/simple_animal/pet/familiar/user = owner
 	if(!istype(user))
 		return FALSE
+
 	if(isturf(user.loc))
 		// we're on the ground somewhere, so we should become orb
 		var/obj/item/magic/familiar/familiar_spirit/spirit = new /obj/item/magic/familiar/familiar_spirit(user.loc)
@@ -128,19 +175,31 @@
 		spirit.icon_state = user.icon_living
 		spirit.name = user.name
 		spirit.desc = "A small orb, containing the spirit of [user.name]."
+		user.clear_familiar_click_intercepts()
 		user.forceMove(spirit)
 		user.status_flags |= GODMODE
+		user.reset_perspective()
+		user.refresh_familiar_action_buttons(TRUE)
 		return TRUE
-	else
-		if(user.health<=0) // you shouldn't be able to cast this while dead, but just in case
-			return FALSE
-		var/obj/item/magic/familiar/familiar_spirit/spirit = user.loc
-		if(!istype(spirit)) // we might be inside another item like warden tools
-			return FALSE
-		user.forceMove(get_turf(user))
-		user.status_flags &= ~GODMODE
-		qdel(spirit)
-		return TRUE
+
+	if(user.health <= 0) // you shouldn't be able to cast this while dead, but just in case
+		return FALSE
+
+	var/obj/item/magic/familiar/familiar_spirit/spirit = user.loc
+	if(!istype(spirit)) // we might be inside another item like warden tools
+		return FALSE
+
+	var/turf/T = get_turf(user)
+	if(!T)
+		return FALSE
+
+	user.clear_familiar_click_intercepts()
+	user.forceMove(T)
+	user.status_flags &= ~GODMODE
+	user.reset_perspective()
+	user.refresh_familiar_action_buttons(TRUE)
+	qdel(spirit)
+	return TRUE
 
 /datum/action/cooldown/spell/fae_brew
 	name = "Alchemical Stomach"
@@ -320,6 +379,16 @@
 	cooldown_time = 30 SECONDS
 	charge_required = FALSE
 
+/datum/action/cooldown/spell/arcyne_forge/elemental/IsAvailable(feedback = FALSE)
+	var/mob/living/simple_animal/pet/familiar/user = owner
+	if(istype(user) && conjured_item && !QDELETED(conjured_item) && user.loc == conjured_item)
+		var/old_check_flags = check_flags
+		check_flags &= ~AB_CHECK_IMMOBILE
+		. = ..(feedback)
+		check_flags = old_check_flags
+		return
+	return ..(feedback)
+
 /datum/action/cooldown/spell/arcyne_forge/elemental/cast(atom/cast_on)
 	. = ..()
 	var/mob/living/simple_animal/pet/familiar/H = owner
@@ -353,18 +422,45 @@
 	R.AddComponent(/datum/component/conjured_item, GLOW_COLOR_EARTHEN)
 	RegisterSignal(R, COMSIG_ITEM_BROKEN, PROC_REF(revert))
 	RegisterSignal(R, COMSIG_ITEM_DROPPED, PROC_REF(revert_perspective))
+	H.clear_familiar_click_intercepts()
 	H.forceMove(R)
+	H.reset_perspective()
+	H.refresh_familiar_action_buttons(TRUE)
 	conjured_item = R
 	return TRUE
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/proc/revert_perspective()
-	owner.reset_perspective()
+	var/mob/living/simple_animal/pet/familiar/H = owner
+	if(!istype(H))
+		return
+	H.reset_perspective()
+	H.refresh_familiar_action_buttons(TRUE)
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/proc/revert()
-	if(conjured_item)
-		owner.forceMove(get_turf(owner))
-		owner.status_flags &= ~GODMODE
+	var/mob/living/simple_animal/pet/familiar/H = owner
+	if(!istype(H))
 		QDEL_NULL(conjured_item)
+		return
+
+	if(!conjured_item || QDELETED(conjured_item))
+		H.status_flags &= ~GODMODE
+		H.clear_familiar_click_intercepts()
+		H.reset_perspective()
+		H.refresh_familiar_action_buttons(TRUE)
+		return
+
+	var/turf/T = get_turf(H)
+	if(!T)
+		T = get_turf(conjured_item)
+	if(!T)
+		return
+
+	H.clear_familiar_click_intercepts()
+	H.forceMove(T)
+	H.status_flags &= ~GODMODE
+	H.reset_perspective()
+	H.refresh_familiar_action_buttons(TRUE)
+	QDEL_NULL(conjured_item)
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/void // lmao
 	name = "Void Forge"


### PR DESCRIPTION
## About The Pull Request

Фикшу лаги за фамильяров и формы ведьмы. А также исправил абилку у фамильяров, которая их превращала в кирпич, буквально в кирпич без абилок. Теперь они  могут стать айтемом и потом обратно вернуться.

## Testing Evidence

На локалке тестил, все было отлично. Но как будет на живом сервере в плане лагов - не могу точно сказать.

## Why It's Good For The Game

Круто иметь меньше сломанных механов

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Исправлены лаги за фамильяров и за формы ведьмы
fix: Исправлена абилка Spirit Transformation. Теперь она не блочит  способности.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
