### PR TITLE
Фикс двойной статпанели

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1328,7 +1328,10 @@ GLOBAL_VAR_INIT(mobids, 1)
 	SEND_SIGNAL(src, COMSIG_MOB_GET_STATUS_TAB_ITEMS, .)
 	if(client)
 		. += list(list("IC DATE: ", "[get_current_ic_date_as_string()] (CLICK FOR CALENDAR)", "src=[REF(client)];statbrowser_calendar=1"))
-		. += list(list("tod", GLOB.tod, "IC TIME: [get_current_ic_time_as_string()]"))
+		var/current_tod = GLOB.tod
+		if(!istext(current_tod) || !length(current_tod))
+			current_tod = "day"
+		. += list(list("tod", current_tod, "IC TIME: [get_current_ic_time_as_string()]"))
 	return .
 
 /mob/proc/get_stats_tab_items()

--- a/ta_statpanel/ta_statpanel/index.jsx
+++ b/ta_statpanel/ta_statpanel/index.jsx
@@ -1,5 +1,5 @@
 import { h, render, Fragment } from 'preact';
-import { useState, useEffect, useRef, useCallback, useMemo } from 'preact/hooks';
+import { useState, useEffect, useCallback, useMemo } from 'preact/hooks';
 
 var decoder = decodeURIComponent || unescape;
 
@@ -207,52 +207,63 @@ function addVerbList(payload) {
   if (changed) setState({ verbs, verbTabs });
 }
 
+function statusValue(value, fallback = '') {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === 'string') return value;
+  return String(value);
+}
+
 function StatusRow({ part }) {
   if (!Array.isArray(part)) {
-    if (typeof part === 'string' && part.trim() === '') return <br />;
-    return <div>{part}</div>;
+    const text = statusValue(part);
+    if (text.trim() === '') return <br />;
+    return <div>{text}</div>;
   }
 
-  if (part?.[0] === 'spinner') return <BrailleSpinner />;
+  const kind = statusValue(part[0]);
+  if (kind === 'spinner') return <BrailleSpinner />;
 
-  switch (part[0]) {
+  switch (kind) {
     case 'tod': {
-      const todWord = part[1].charAt(0).toUpperCase() + part[1].slice(1);
-      const todText = part[2];
+      const todClass = statusValue(part[1], 'day') || 'day';
+      const todWord = todClass.charAt(0).toUpperCase() + todClass.slice(1);
+      const todText = statusValue(part[2]);
       const idx = todText.indexOf(todWord);
       if (idx === -1) return <div>{todText}</div>;
       return (
         <div>
           {todText.slice(0, idx)}
-          <span className={'tod-' + part[1]}>{todWord}</span>
+          <span className={'tod-' + todClass}>{todWord}</span>
           {todText.slice(idx + todWord.length)}
         </div>
       );
     }
     case 'load': {
+      const loadClass = statusValue(part[1], 'low') || 'low';
+      const loadText = statusValue(part[2]);
       if (part[3] !== undefined) {
         return (
           <div>
-            {part[2]}
-            <span className={'load-' + part[1]}>{part[3]}</span>
+            {loadText}
+            <span className={'load-' + loadClass}>{statusValue(part[3])}</span>
           </div>
         );
       }
-      return <div className={'load-' + part[1]}>{part[2]}</div>;
+      return <div className={'load-' + loadClass}>{loadText}</div>;
     }
     case 'same_line':
-      return <div><a href={'byond://?' + part[2]}>{part[1]}</a></div>;
+      return <div><a href={'byond://?' + statusValue(part[2])}>{statusValue(part[1])}</a></div>;
     default: {
-      if (part[0].trim() === '') return <br />;
+      if (kind.trim() === '') return <br />;
       if (part[2]) {
         return (
           <div>
-            {part[0]}
-            <a href={'byond://?' + part[2]}>{part[1]}</a>
+            {kind}
+            <a href={'byond://?' + statusValue(part[2])}>{statusValue(part[1])}</a>
           </div>
         );
       }
-      return <div>{part}</div>;
+      return <div>{part.map((piece) => statusValue(piece)).join('')}</div>;
     }
   }
 }
@@ -260,17 +271,7 @@ function StatusRow({ part }) {
 function RoundInfoPanel() {
   const s = useStatState();
 
-  const sentFixRef = useRef(false);
-  useEffect(() => {
-    if (s.verbTabs.length === 0) {
-      if (!sentFixRef.current) {
-        sentFixRef.current = true;
-        Byond.command('Fix-Stat-Panel');
-      }
-    } else {
       sentFixRef.current = false;
-    }
-  }, [s.verbTabs.length]);
 
   return (
     <table>

--- a/ta_statpanel/ta_statpanel/index.jsx
+++ b/ta_statpanel/ta_statpanel/index.jsx
@@ -270,9 +270,6 @@ function StatusRow({ part }) {
 
 function RoundInfoPanel() {
   const s = useStatState();
-
-      sentFixRef.current = false;
-
   return (
     <table>
       {s.statusTabParts.map((part, i) => (


### PR DESCRIPTION
## About The Pull Request

Починил причину из-за которой была двойная статпанель

## Testing Evidence

На локалке у меня все было норм при тестах.

## Why It's Good For The Game

Две статпанели это не круто

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Исправлено появление второй статпанели при заходе в раунд с включенной вкладкой Round Info
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
