### PR TITLE
Донаторкиты с грензельскими шмотками

### DIFF
--- a/code/datums/loadout.dm
+++ b/code/datums/loadout.dm
@@ -4139,6 +4139,30 @@ GLOBAL_LIST_EMPTY(loadout_items_by_category)
 	path = /obj/item/rogueweapon/scabbard/sheath/royal
 	triumph_cost = 13
 
+/datum/loadout_item/grenzelhoft_kit_gambeson
+	name = "Donator Kit - Grenzelhoft Hip-Shirt"
+	category = list("Одежда", "Донат")
+	path = /obj/item/enchantingkit/grenzel_gambeson
+	donatitem = TRUE
+
+/datum/loadout_item/grenzelhoft_kit_shoes
+	name = "Donator Kit - Grenzelhoft Boots"
+	category = list("Обувь", "Донат")
+	path = /obj/item/enchantingkit/grenzel_shoes
+	donatitem = TRUE
+
+/datum/loadout_item/grenzelhoft_kit_pants
+	name = "Donator Kit - Grenzelhoft Paumpers"
+	category = list("Одежда", "Донат")
+	path = /obj/item/enchantingkit/grenzel_pants
+	donatitem = TRUE
+
+/datum/loadout_item/grenzelhoft_kit_gloves
+	name = "Donator Kit - Grenzelhoft Gloves"
+	category = list("Одежда", "Донат")
+	path = /obj/item/enchantingkit/grenzel_gloves
+	donatitem = TRUE
+
 /datum/loadout_item/donat/sagesbighat
 	name = "Большая шляпа мудреца"
 	category = list("Головные уборы", "Донат")

--- a/modular_twilight_axis/code/game/objects/items/donator_modkit.dm
+++ b/modular_twilight_axis/code/game/objects/items/donator_modkit.dm
@@ -254,37 +254,38 @@
 	icon_loadout = /obj/item/clothing/under/roguetown/trou/leather/etrpants
 
 /obj/item/enchantingkit/grenzel_gambeson
-    name = "'Grenzelhoft Hip-Shirt' morphing elixir"
-    desc = "A small container of special morphing dust, perfect to make a specific item. Required: Gambeson or Padded Gambeson."
-    target_items = list(
-        /obj/item/clothing/suit/roguetown/armor/gambeson/heavy = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft,
-        /obj/item/clothing/suit/roguetown/armor/gambeson = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
-    )
-    icon_loadout = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
+	name = "'Grenzelhoft Hip-Shirt' morphing elixir"
+	desc = "A small container of special morphing dust, perfect to make a specific item. Required: Gambeson or Padded Gambeson."
+	target_items = list(
+		/obj/item/clothing/suit/roguetown/armor/gambeson/heavy = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft,
+		/obj/item/clothing/suit/roguetown/armor/gambeson = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
+	)
+	icon_loadout = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
 
 /obj/item/enchantingkit/grenzel_shoes
-    name = "'Grenzelhoft Boots' morphing elixir"
-    desc = "A small container of special morphing dust, perfect to make a specific item. Required: Heavy Leather Boots or Dark Boots."
-    target_items = list(
-        /obj/item/clothing/shoes/roguetown/boots/leather/reinforced = /obj/item/clothing/shoes/roguetown/grenzelhoft,
-        /obj/item/clothing/shoes/roguetown/boots = /obj/item/clothing/shoes/roguetown/grenzelhoft
-    )
-    icon_loadout = /obj/item/clothing/shoes/roguetown/grenzelhoft
+	name = "'Grenzelhoft Boots' morphing elixir"
+	desc = "A small container of special morphing dust, perfect to make a specific item. Required: Heavy Leather Boots or Dark Boots."
+	target_items = list(
+		/obj/item/clothing/shoes/roguetown/boots/leather/reinforced = /obj/item/clothing/shoes/roguetown/grenzelhoft,
+		/obj/item/clothing/shoes/roguetown/boots = /obj/item/clothing/shoes/roguetown/grenzelhoft
+	)
+	icon_loadout = /obj/item/clothing/shoes/roguetown/grenzelhoft
 
 /obj/item/enchantingkit/grenzel_pants
-    name = "'Grenzelhoft Paumpers' morphing elixir"
-    desc = "A small container of special morphing dust, perfect to make a specific item. Required: Hardened Leather Pants or Regular Pants."
-    target_items = list(
-        /obj/item/clothing/under/roguetown/heavy_leather_pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants,
-        /obj/item/clothing/under/roguetown/trou = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants,
-        /obj/item/clothing/under/roguetown/tights = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
-    )
-    icon_loadout = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
+	name = "'Grenzelhoft Paumpers' morphing elixir"
+	desc = "A small container of special morphing dust, perfect to make a specific item. Required: Hardened Leather Pants or Regular Pants."
+	target_items = list(
+		/obj/item/clothing/under/roguetown/heavy_leather_pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants,
+		/obj/item/clothing/under/roguetown/trou = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants,
+		/obj/item/clothing/under/roguetown/tights = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
+	)
+	icon_loadout = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
 
 /obj/item/enchantingkit/grenzel_gloves
-    name = "'Grenzelhoft Gloves' morphing elixir"
-    desc = "A small container of special morphing dust, perfect to make a specific item. Required: Any Gloves."
-    target_items = list(
-        /obj/item/clothing/gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
-    )
-    icon_loadout = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
+	name = "'Grenzelhoft Gloves' morphing elixir"
+	desc = "A small container of special morphing dust, perfect to make a specific item. Required: Any Gloves."
+	target_items = list(
+		/obj/item/clothing/gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
+	)
+	icon_loadout = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
+

--- a/modular_twilight_axis/code/game/objects/items/donator_modkit.dm
+++ b/modular_twilight_axis/code/game/objects/items/donator_modkit.dm
@@ -252,3 +252,39 @@
 		/obj/item/clothing/under/roguetown/brigandinelegs = /obj/item/clothing/under/roguetown/trou/leather/etrpants,
 		/obj/item/clothing/under/roguetown/splintlegs = /obj/item/clothing/under/roguetown/trou/leather/etrpants)
 	icon_loadout = /obj/item/clothing/under/roguetown/trou/leather/etrpants
+
+/obj/item/enchantingkit/grenzel_gambeson
+    name = "'Grenzelhoft Hip-Shirt' morphing elixir"
+    desc = "A small container of special morphing dust, perfect to make a specific item. Required: Gambeson or Padded Gambeson."
+    target_items = list(
+        /obj/item/clothing/suit/roguetown/armor/gambeson/heavy = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft,
+        /obj/item/clothing/suit/roguetown/armor/gambeson = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
+    )
+    icon_loadout = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
+
+/obj/item/enchantingkit/grenzel_shoes
+    name = "'Grenzelhoft Boots' morphing elixir"
+    desc = "A small container of special morphing dust, perfect to make a specific item. Required: Heavy Leather Boots or Dark Boots."
+    target_items = list(
+        /obj/item/clothing/shoes/roguetown/boots/leather/reinforced = /obj/item/clothing/shoes/roguetown/grenzelhoft,
+        /obj/item/clothing/shoes/roguetown/boots = /obj/item/clothing/shoes/roguetown/grenzelhoft
+    )
+    icon_loadout = /obj/item/clothing/shoes/roguetown/grenzelhoft
+
+/obj/item/enchantingkit/grenzel_pants
+    name = "'Grenzelhoft Paumpers' morphing elixir"
+    desc = "A small container of special morphing dust, perfect to make a specific item. Required: Hardened Leather Pants or Regular Pants."
+    target_items = list(
+        /obj/item/clothing/under/roguetown/heavy_leather_pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants,
+        /obj/item/clothing/under/roguetown/trou = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants,
+        /obj/item/clothing/under/roguetown/tights = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
+    )
+    icon_loadout = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
+
+/obj/item/enchantingkit/grenzel_gloves
+    name = "'Grenzelhoft Gloves' morphing elixir"
+    desc = "A small container of special morphing dust, perfect to make a specific item. Required: Any Gloves."
+    target_items = list(
+        /obj/item/clothing/gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
+    )
+    icon_loadout = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves


### PR DESCRIPTION
## About The Pull Request
Добавляет четыре шмотки из грензельхофта как донатор киты, применяемые на соответствующие их уровню брони айтемы.

## Testing Evidence
Запускается + правильно наследует броню у одежды + не даёт брони при применении на одежду без брони
<img width="409" height="171" alt="dreamseeker_boGCugbQ8v" src="https://github.com/user-attachments/assets/7a915358-a35f-4888-b59e-9390a9106b0f" />
<img width="540" height="242" alt="dreamseeker_XfnKbaG1sQ" src="https://github.com/user-attachments/assets/0761bdc1-ade9-4627-956b-b50e268ecd59" />

## Why It's Good For The Game
Чёрная Империя повсюду и везде, хотелось бы носить их крутые рубашки не только на наёмниках.

## Changelog
:cl:
add: Донатор киты для грензельпамперсов
/:cl: