### PR TITLE
Фикс брони Баоты и ауры

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1171,7 +1171,7 @@
 /datum/status_effect/buff/reversion
 	id = "stasis"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/stasis
-	duration = 15 SECONDS // TA EDIT
+	duration = 25 SECONDS
 
 #define CRANKBOX_FILTER "crankboxbuff_glow"
 /atom/movable/screen/alert/status_effect/buff/churnerprotection
@@ -2303,10 +2303,13 @@
 		mob.remove_status_effect(/datum/status_effect/debuff/joybringer_druqks)
 
 /datum/status_effect/joybringer/proc/clear_affected_mobs()
+	if(!affected_mobs)
+		return
+
 	for(var/mob/living/mob in affected_mobs)
 		clear_joybringer_debuff(mob)
 
-	affected_mobs?.Cut()
+	affected_mobs.Cut()
 
 /datum/status_effect/joybringer/proc/on_life()
 	SIGNAL_HANDLER
@@ -2324,9 +2327,10 @@
 		current_mobs += mob
 		mob.apply_status_effect(/datum/status_effect/debuff/joybringer_druqks)
 
-	for(var/mob/living/old_mob in affected_mobs)
-		if(!(old_mob in current_mobs))
-			clear_joybringer_debuff(old_mob)
+	if(affected_mobs)
+		for(var/mob/living/old_mob in affected_mobs)
+			if(!(old_mob in current_mobs))
+				clear_joybringer_debuff(old_mob)
 
 	affected_mobs = current_mobs // TA EDIT END
 

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1171,7 +1171,7 @@
 /datum/status_effect/buff/reversion
 	id = "stasis"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/stasis
-	duration = 25 SECONDS
+	duration = 15 SECONDS // TA EDIT
 
 #define CRANKBOX_FILTER "crankboxbuff_glow"
 /atom/movable/screen/alert/status_effect/buff/churnerprotection
@@ -2240,6 +2240,7 @@
 /datum/status_effect/joybringer
 	id = "joybringer"
 	var/outline_colour = "#a529e8"
+	var/list/affected_mobs = list()
 	duration = -1
 	tick_interval = -1
 	examine_text = span_love("SUBJECTPRONOUN is bathed in Baotha's blessings!")
@@ -2264,22 +2265,70 @@
 
 	RegisterSignal(owner, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
-/datum/status_effect/joybringer/on_remove()
+/datum/status_effect/joybringer/on_remove() // TA EDIT START
 	. = ..()
+
+	clear_affected_mobs()
 
 	owner.remove_filter(JOYBRINGER_FILTER)
 	owner.remove_overlay(JOYBRINGER_LAYER)
 
 	UnregisterSignal(owner, COMSIG_LIVING_LIFE)
 
+/datum/status_effect/joybringer/proc/valid_target(mob/living/mob)
+	if(!owner || QDELETED(owner) || !mob || QDELETED(mob))
+		return FALSE
+
+	if(HAS_TRAIT(mob, TRAIT_CRACKHEAD) || HAS_TRAIT(mob, TRAIT_PSYDONITE))
+		return FALSE
+
+	var/turf/owner_turf = get_turf(owner)
+	var/turf/mob_turf = get_turf(mob)
+	if(!owner_turf || !mob_turf)
+		return FALSE
+
+	if(owner_turf.z != mob_turf.z)
+		return FALSE
+
+	if(get_dist(owner_turf, mob_turf) > 2)
+		return FALSE
+
+	return TRUE
+
+/datum/status_effect/joybringer/proc/clear_joybringer_debuff(mob/living/mob)
+	if(!mob || QDELETED(mob))
+		return
+
+	if(mob.has_status_effect(/datum/status_effect/debuff/joybringer_druqks))
+		mob.remove_status_effect(/datum/status_effect/debuff/joybringer_druqks)
+
+/datum/status_effect/joybringer/proc/clear_affected_mobs()
+	for(var/mob/living/mob in affected_mobs)
+		clear_joybringer_debuff(mob)
+
+	affected_mobs?.Cut()
+
 /datum/status_effect/joybringer/proc/on_life()
 	SIGNAL_HANDLER
 
+	var/turf/owner_turf = get_turf(owner)
+	if(!owner_turf)
+		clear_affected_mobs()
+		return
+
+	var/list/current_mobs = list()
 	for(var/mob/living/mob in get_hearers_in_view(2, owner))
-		if(HAS_TRAIT(mob, TRAIT_CRACKHEAD) || HAS_TRAIT(mob, TRAIT_PSYDONITE))
+		if(!valid_target(mob))
 			continue
 
+		current_mobs += mob
 		mob.apply_status_effect(/datum/status_effect/debuff/joybringer_druqks)
+
+	for(var/mob/living/old_mob in affected_mobs)
+		if(!(old_mob in current_mobs))
+			clear_joybringer_debuff(old_mob)
+
+	affected_mobs = current_mobs // TA EDIT END
 
 #undef JOYBRINGER_FILTER
 

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -22,6 +22,8 @@
 	/// Holder for disruption timer
 	var/disrupttimer
 
+	var/mob/living/current_regen_owner // TA EDIT
+
 	/// To make repairs relative or not.
 	/// In other words, if you use relative repairing then it will use a different repair interval.
 	/// Repair_time becomes how long it will take on average for the armor to fully repair itself.
@@ -54,18 +56,57 @@
 		setup_auto_repair()
 	addtimer(CALLBACK(src, PROC_REF(check_owner)), 5 SECONDS)
 
+/obj/item/clothing/suit/roguetown/armor/regenerating/Destroy() // TA EDIT START
+	clear_regen_owner()
+	if(reptimer)
+		deltimer(reptimer)
+		reptimer = null
+	if(disrupttimer)
+		deltimer(disrupttimer)
+		disrupttimer = null
+	return ..()
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/equipped(mob/living/user, slot)
+	. = ..()
+	if(slot == SLOT_SHIRT || slot == SLOT_ARMOR)
+		set_regen_owner(user)
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/dropped(mob/living/user)
+	. = ..()
+	if(current_regen_owner == user)
+		clear_regen_owner()
+
 /obj/item/clothing/suit/roguetown/armor/regenerating/proc/check_owner()
 	if(!ishuman(loc))
 		return
-	var/mob/living/L = loc
-	RegisterSignal(L, COMSIG_MOB_ITEM_BEING_ATTACKED, PROC_REF(process_attack))
-	RegisterSignal(L, COMSIG_MOB_ATTACKED_BY_HAND, PROC_REF(process_attack))
+	set_regen_owner(loc)
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/proc/set_regen_owner(mob/living/new_owner)
+	if(current_regen_owner == new_owner)
+		return
+	clear_regen_owner()
+	if(!new_owner)
+		return
+	current_regen_owner = new_owner
+	RegisterSignal(current_regen_owner, COMSIG_MOB_ITEM_BEING_ATTACKED, PROC_REF(process_attack))
+	RegisterSignal(current_regen_owner, COMSIG_MOB_ATTACKED_BY_HAND, PROC_REF(process_attack))
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/proc/clear_regen_owner()
+	if(!current_regen_owner)
+		return
+	UnregisterSignal(current_regen_owner, COMSIG_MOB_ITEM_BEING_ATTACKED)
+	UnregisterSignal(current_regen_owner, COMSIG_MOB_ATTACKED_BY_HAND)
+	current_regen_owner = null
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/proc/process_attack(mob/living/parent, mob/living/target, mob/user, obj/item/I)
+	if(parent != current_regen_owner)
+		return
 	is_disrupted = TRUE
 	if(reptimer)
 		deltimer(reptimer)
-	disrupttimer = addtimer(CALLBACK(src, PROC_REF(revert_disrupt)), 60 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
+		reptimer = null 
+		to_chat(parent, span_notice(repairmsg_stop))
+	disrupttimer = addtimer(CALLBACK(src, PROC_REF(revert_disrupt)), 60 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE) // TA EDIT END
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/proc/revert_disrupt()
 	if(is_disrupted)

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -90,21 +90,33 @@
 	current_regen_owner = new_owner
 	RegisterSignal(current_regen_owner, COMSIG_MOB_ITEM_BEING_ATTACKED, PROC_REF(process_attack))
 	RegisterSignal(current_regen_owner, COMSIG_MOB_ATTACKED_BY_HAND, PROC_REF(process_attack))
+	RegisterSignal(current_regen_owner, COMSIG_PARENT_QDELETING, PROC_REF(on_regen_owner_qdeleted))
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/proc/on_regen_owner_qdeleted(datum/source)
+	SIGNAL_HANDLER
+
+	if(source != current_regen_owner)
+		return
+
+	clear_regen_owner()
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/proc/clear_regen_owner()
 	if(!current_regen_owner)
 		return
 	UnregisterSignal(current_regen_owner, COMSIG_MOB_ITEM_BEING_ATTACKED)
 	UnregisterSignal(current_regen_owner, COMSIG_MOB_ATTACKED_BY_HAND)
+	UnregisterSignal(current_regen_owner, COMSIG_PARENT_QDELETING)
 	current_regen_owner = null
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/proc/process_attack(mob/living/parent, mob/living/target, mob/user, obj/item/I)
+	SIGNAL_HANDLER
+
 	if(parent != current_regen_owner)
 		return
 	is_disrupted = TRUE
 	if(reptimer)
 		deltimer(reptimer)
-		reptimer = null 
+		reptimer = null
 		to_chat(parent, span_notice(repairmsg_stop))
 	disrupttimer = addtimer(CALLBACK(src, PROC_REF(revert_disrupt)), 60 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE) // TA EDIT END
 


### PR DESCRIPTION
## About The Pull Request

Теперь аура баотистов должна адекватно убираться. 
По баг-репорту: https://discord.com/channels/1133928966915358822/1523446472098451587
А также исправлен баг того, что броняБаоты регенирировались во время боя.

## Testing Evidence

Тестил на локалке. С броней уверен на 100%, насчет ауры уверен на 90%. На локалке не смог обнаружить проблемы.

## Why It's Good For The Game

Броня что не регенится во время боя и аура, которая пропадает, это круто

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Исправлен баг с регеном брони Баоты во время боя
fix: Исправлена проблема из-за которой аура Баоты не убиралась у персонажей, что ушли за ее радиус
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
