### PR TITLE
Новое лодаут меню

### DIFF
--- a/code/modules/asset_cache/assets/loadout.dm
+++ b/code/modules/asset_cache/assets/loadout.dm
@@ -1,19 +1,29 @@
-/datum/asset/spritesheet/loadout_icons
+/datum/asset/spritesheet_batched/loadout_icons
 	name = "loadout_icons"
+	ignore_dir_errors = TRUE
 
-/datum/asset/spritesheet/loadout_icons/create_spritesheets()
+/datum/asset/spritesheet_batched/loadout_icons/create_spritesheets()
+	var/list/ids = list()
 	for(var/key in GLOB.loadout_items_by_name)
 		var/datum/loadout_item/item = GLOB.loadout_items_by_name[key]
 		var/atom/movable/typepath = item.path
-		if(ispath(typepath, /obj/item/enchantingkit/bat))
-			var/obj/item/enchantingkit/kit_typepath = typepath
-			typepath = kit_typepath.result_item
 		var/icon = typepath::icon
 		var/icon_state = typepath::icon_state
-
-		
+		if(ispath(typepath, /obj/item/enchantingkit))
+			var/obj/item/enchantingkit/kit_typepath = typepath
+			var/obj/item/result = initial(kit_typepath.result_item) || initial(kit_typepath.icon_loadout)
+			icon = initial(result.icon)
+			icon_state = initial(result.icon_state)
 
 		if(!icon || !icon_state)
 			continue
 
-		Insert("[sanitize_css_class_name("loadout_[REF(item)]")]", icon, icon_state)
+		var/id = sanitize_css_class_name("[typepath]")
+
+		if(id in ids)
+			continue
+
+		ids += id
+		var/datum/universal_icon/new_icon = uni_icon(icon, icon_state)
+		new_icon.scale(128,128)
+		insert_icon(id, new_icon)

--- a/modular_twilight_axis/code/modules/client/preferences_loadout.dm
+++ b/modular_twilight_axis/code/modules/client/preferences_loadout.dm
@@ -91,23 +91,14 @@
 		ui = new(user, src, "LoadoutPanel")
 		ui.open()
 
-/datum/loadout_panel/ui_data(mob/user)
+/datum/loadout_panel/ui_static_data(mob/user)
 	var/list/data = list()
 	var/list/categories = list()
 	var/datum/preferences/user_prefs = user.client.prefs
-	var/list/selected_loadout_items = user_prefs.selected_loadout_items
 
 	var/donat_level = check_patreon_lvl(user.ckey)
 	var/triumph_discount = get_donator_triumph_discount(user.ckey)
 	var/is_donator_status = (triumph_discount > 0) || is_donator(user.ckey)
-
-	var/total_triumph_cost = 0
-	for(var/item_name in selected_loadout_items)
-		var/datum/loadout_item/selected_item = GLOB.loadout_items_by_name[item_name]
-		if(selected_item?.triumph_cost)
-			total_triumph_cost += selected_item.triumph_cost
-
-	var/triumph_discount_used = min(triumph_discount, total_triumph_cost)
 
 	for(var/cat_name in GLOB.loadout_items_by_category)
 		var/list/items_in_cat = GLOB.loadout_items_by_category[cat_name]
@@ -121,42 +112,54 @@
 			if(item.ckeywhitelist && !item.donator_ckey_check(user.ckey))
 				continue
 
-			var/icon = item.path::icon
-			var/icon_state = item.path::icon_state
-			var/selected = (item.name in selected_loadout_items)
+			var/atom/movable/icon_source_path = item.path
 			var/lock_reason = item.get_loadout_lock_reason(user)
 
-			if(ispath(item.path, /obj/item/enchantingkit))
-				var/obj/item/enchantingkit/kit_typepath = item.path
-				var/obj/result_item = kit_typepath.result_item
-				var/obj/icon_loadout = kit_typepath.icon_loadout
-				if(result_item != null)
-					icon = result_item::icon
-					icon_state = result_item::icon_state
-				else
-					icon = icon_loadout::icon
-					icon_state = icon_loadout::icon_state
+			var/icon = icon_source_path::icon
+			var/icon_state = icon_source_path::icon_state
+			
+			var/id = sanitize_css_class_name("[icon_source_path]")
+
+			var/icon_class_name = "loadout_icons128x128 [id]"
 
 			categories[cat_name][item.name] += list(
 				name = item.name,
 				path = item.path,
 				icon = icon,
 				icon_state = icon_state,
+				icon_class_name = icon_class_name,
 				isDonatorItem = item.donatitem,
-				isSelected = selected,
 				unavailable = !isnull(lock_reason),
 				unavailableReason = lock_reason,
 				requiredTier = item.donat_tier,
-				triumphCost = item.triumph_cost
+				triumphCost = item.triumph_cost,
 			)
 
 	data["categories"] = categories
 	data["isDonator"] = is_donator_status
 	data["donatTier"] = donat_level
 	data["triumphDiscount"] = triumph_discount
+	data["maxLoadoutSlots"] = user_prefs.get_loadout_size(user)
+
+	return data
+
+/datum/loadout_panel/ui_data(mob/user)
+	var/list/data = list()
+	var/datum/preferences/user_prefs = user.client.prefs
+	var/list/selected_loadout_items = user_prefs.selected_loadout_items
+
+	var/total_triumph_cost = 0
+	for(var/item_name in selected_loadout_items)
+		var/datum/loadout_item/selected_item = GLOB.loadout_items_by_name[item_name]
+		if(selected_item?.triumph_cost)
+			total_triumph_cost += selected_item.triumph_cost
+
+	var/triumph_discount = get_donator_triumph_discount(user.ckey)
+	var/triumph_discount_used = min(triumph_discount, total_triumph_cost)
+
+	data["selectedLoadoutItems"] = selected_loadout_items
 	data["triumphDiscountUsed"] = triumph_discount_used
 	data["curLoadoutSlots"] = selected_loadout_items.len
-	data["maxLoadoutSlots"] = user_prefs.get_loadout_size(user)
 
 	return data
 
@@ -201,7 +204,7 @@
 
 /datum/loadout_panel/ui_assets(mob/user)
 	return list(
-		get_asset_datum(/datum/asset/spritesheet/loadout_icons)
+		get_asset_datum(/datum/asset/spritesheet_batched/loadout_icons)
 	)
 
 /datum/preferences/proc/get_max_save_slots(plevel)

--- a/tgui/packages/tgui/interfaces/LoadoutPanel.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutPanel.tsx
@@ -135,6 +135,69 @@ export const LoadoutPanel = () => {
                   </Box>
                 </Stack.Item>
               ) : null}
+              <Stack.Item>
+                <Box
+                  mt={2}
+                  style={{
+                    minHeight: '180px',
+                    maxHeight: '200px',
+                    overflowY: 'auto',
+                    overflowX: 'hidden',
+                    padding: '8px',
+                    border: '1px solid rgba(120, 150, 190, 0.65)',
+                    borderRadius: '6px',
+                    backgroundColor: 'rgba(0, 0, 0, 0.14)',
+                  }}
+                >
+                  <Box
+                    mb={1}
+                    textAlign="center"
+                    style={{
+                      fontSize: '16px',
+                      fontWeight: 'bold',
+                      textShadow: '1px 1px 3px rgba(0,0,0,0.8)',
+                    }}
+                  >
+                    Выбранные предметы:
+                  </Box>
+
+                  {(data.selectedLoadoutItems ?? []).length ? (
+                    (data.selectedLoadoutItems ?? []).map((item) => (
+                      <Box
+                        key={item}
+                        mb={1}
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          gap: '6px',
+                        }}
+                      >
+                        <Box
+                          style={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                          tooltip={item}
+                        >
+                          {item}
+                        </Box>
+                        <Button
+                          color="danger"
+                          onClick={() => act('remove', { item })}
+                        >
+                          Удалить
+                        </Button>
+                      </Box>
+                    ))
+                  ) : (
+                    <Box color="label" textAlign="center">
+                      Пока ничего не выбрано.
+                    </Box>
+                  )}
+                </Box>
+              </Stack.Item>
             </Stack>
           </Stack.Item>
 
@@ -195,56 +258,56 @@ export const LoadoutPanel = () => {
                     gap: '8px',
                   }}
                 >
-                {filteredItems.map((item, index) => (
-                  <div
-                    key={item?.name || item?.path || index}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      minHeight: '64px',
-                      borderRadius: '4px',
-                    }}
-                  >
-                    <Box
+                  {filteredItems.map((item, index) => (
+                    <div
+                      key={item?.name || item?.path || index}
                       style={{
                         display: 'flex',
-                        flexDirection: 'column',
                         alignItems: 'center',
-                        justifyContent: 'center',
-                        minWidth: '96px',
-                        flexShrink: 0,
+                        minHeight: '64px',
+                        borderRadius: '4px',
                       }}
                     >
-                      <Button
+                      <Box
                         style={{
-                          backgroundColor: '#141414',
-                          padding: '16px',
-                          width: '96px',
-                          height: '96px',
-                          border: '2x solid red',
-                          borderColor: `${item?.unavailable ? '#a77a18' : (selectedSet.has(item?.name)? '#a71818' : '#24a718')}`,
-                          borderRadius: '8px',
-                        }}
-                        tooltip={
-                          `${item?.unavailable 
-                              ? item?.unavailableReason || (item?.requiredTier ? "Недоступно. Требуется уровень:"+item.requiredTier : 'Недоступно.') 
-                              : item?.name || 'Без названия'}`}
-                        onClick={() => {
-                          if (selectedSet.has(item?.name)) {
-                            act('remove', { item: item?.name || item?.path });
-                          } else {
-                            act('add', { item: item?.name || item?.path });
-                          }
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          minWidth: '96px',
+                          flexShrink: 0,
                         }}
                       >
-                        <Box
-                          inline
-                          verticalAlign="middle"
-                          className={item.icon_class_name}
+                        <Button
                           style={{
-                            transform: 'scale(0.67) translate(-51px, -50px)',
+                            backgroundColor: '#141414',
+                            padding: '16px',
+                            width: '96px',
+                            height: '96px',
+                            border: '2x solid red',
+                            borderColor: `${item?.unavailable ? '#a77a18' : (selectedSet.has(item?.name)? '#a71818' : '#24a718')}`,
+                            borderRadius: '8px',
+                          }}
+                          tooltip={
+                            `${item?.unavailable
+                              ? item?.unavailableReason || (item?.requiredTier ? "Недоступно. Требуется уровень:"+item.requiredTier : 'Недоступно.')
+                              : item?.name || 'Без названия'}`}
+                          onClick={() => {
+                            if (selectedSet.has(item?.name)) {
+                              act('remove', { item: item?.name || item?.path });
+                            } else {
+                              act('add', { item: item?.name || item?.path });
+                            }
                           }}
                         >
+                          <Box
+                            inline
+                            verticalAlign="middle"
+                            className={item.icon_class_name}
+                            style={{
+                              transform: 'scale(0.67) translate(-51px, -50px)',
+                            }}
+                          >
                             {item?.triumphCost ? (
                               <Box
                                 style={{
@@ -280,11 +343,11 @@ export const LoadoutPanel = () => {
                                 Донат тир {item.requiredTier && item.requiredTier > 0 ? item.requiredTier : 1}
                               </Box>
                             ) : null}
-                        </Box>
-                      </Button>
-                    </Box>
-                  </div>
-                ))}
+                          </Box>
+                        </Button>
+                      </Box>
+                    </div>
+                  ))}
                 </div>
               </Stack.Item>
             </Stack>

--- a/tgui/packages/tgui/interfaces/LoadoutPanel.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutPanel.tsx
@@ -75,30 +75,168 @@ export const LoadoutPanel = () => {
     !!data.isDonator && data.triumphDiscount > 0;
 
   return (
-    <Window title="Лодаут" width={1000} height={700}>
+    <Window
+      title="Лодаут"
+      buttons={
+        <Button
+          tooltip={`Выберите предметы для вашего персонажа.
+Вы их сможете забрать, когда нажмете правой кнопкой мыши по статуе или дереву.
+Рескины на оружие (Donator kit) являются просто рескинами, чтобы его получить используйте зелье на соответствующем предмете.`}
+          tooltipPosition="bottom"
+          style={{
+            position: 'fixed',
+            top: '9px',
+            left: '92px',
+            zIndex: 103,
+            minWidth: '0',
+            width: '16px',
+            height: '16px',
+            padding: '0',
+            border: 'none',
+            boxShadow: 'none',
+            background: 'none',
+            textAlign: 'center',
+            lineHeight: '16px',
+            fontSize: '13px',
+            fontWeight: 'bold',
+            color: '#d7b6b6',
+            textShadow: '0 0 4px rgba(255,255,255,0.35)',
+            cursor: 'help',
+          }}
+        >
+          ?
+        </Button>
+      }
+      width={1200}
+      height={700}
+    >
       <Window.Content>
         <Stack fill>
           <Stack.Item width="300px">
             <Stack vertical textAlign="justify">
-              <Stack.Item>
-                <h2>Выберите предметы для вашего персонажа.</h2>
-              </Stack.Item>
-              <Stack.Item>
-                <h2>
-                  Вы их сможете забрать, когда нажмете правой кнопкой мыши по статуе
-                  или дереву.
-                </h2>
-              </Stack.Item>
-              <Stack.Item>
-                <h4>
-                  Рескины на оружие (Donator kit) являются просто рескинами, чтобы
-                  его получить используйте зелье на соответствующем предмете.
-                </h4>
-              </Stack.Item>
-              <Stack.Item>
+              <Stack.Item style={{ textAlign: 'center' }}>
                 <Button onClick={() => act('boosty')}>
                   <h3>Поддержать сервер</h3>
                 </Button>
+              </Stack.Item>
+              <Stack.Item>
+                <Box
+                  mt={1}
+                  style={{
+                    fontSize: '13px',
+                    lineHeight: 1.35,
+                    textAlign: 'center',
+                    color: '#d7b6b6',
+                  }}
+                >
+                  Для меценатов в зависимости от уровня подписки(
+                  <Button
+                    tooltip="Т1 - дает 7 слотов вещей, 3 скидочных триумфа, 40 слотов персонажей и вещи своего тира."
+                    tooltipPosition="bottom"
+                    style={{
+                      minWidth: '0',
+                      width: 'auto',
+                      height: 'auto',
+                      padding: '0',
+                      border: 'none',
+                      boxShadow: 'none',
+                      background: 'none',
+                      lineHeight: 'inherit',
+                      verticalAlign: 'baseline',
+                      color: '#facc15',
+                      fontWeight: 'bold',
+                      cursor: 'help',
+                    }}
+                  >
+                    1
+                  </Button>
+                  ,{' '}
+                  <Button
+                    tooltip="Т2 - дает 11 слотов вещей, 5 скидочных триумфа, 60 слотов персонажей, возможность поменять цвет в дискорде, кастомную боевую музыку и вещи своего тира."
+                    tooltipPosition="bottom"
+                    style={{
+                      minWidth: '0',
+                      width: 'auto',
+                      height: 'auto',
+                      padding: '0',
+                      border: 'none',
+                      boxShadow: 'none',
+                      background: 'none',
+                      lineHeight: 'inherit',
+                      verticalAlign: 'baseline',
+                      color: '#facc15',
+                      fontWeight: 'bold',
+                      cursor: 'help',
+                    }}
+                  >
+                    2
+                  </Button>
+                  ,{' '}
+                  <Button
+                    tooltip="Т3 - дает 17 слотов вещей, 7 скидочных триумфа, 80 слотов персонажей, возможность поменять цвет в дискорде, кастомную боевую музыку и вещи своего тира. Также дается возможность раз в 2 раунда с повышенным приоритетом зайти за роль, имеющую более 2 слотов."
+                    tooltipPosition="bottom"
+                    style={{
+                      minWidth: '0',
+                      width: 'auto',
+                      height: 'auto',
+                      padding: '0',
+                      border: 'none',
+                      boxShadow: 'none',
+                      background: 'none',
+                      lineHeight: 'inherit',
+                      verticalAlign: 'baseline',
+                      color: '#facc15',
+                      fontWeight: 'bold',
+                      cursor: 'help',
+                    }}
+                  >
+                    3
+                  </Button>
+                  ,{' '}
+                  <Button
+                    tooltip="Т4 - дает 21 слотов вещей, 10 скидочных триумфа, 100 слотов персонажей, возможность поменять цвет в дискорде, кастомную боевую музыку и вещи своего тира. Также дается возможность с повышенным приоритетом зайти за роль, имеющую более 2 слотов, в отличии от Т3 без КД в 2 раунда."
+                    tooltipPosition="bottom"
+                    style={{
+                      minWidth: '0',
+                      width: 'auto',
+                      height: 'auto',
+                      padding: '0',
+                      border: 'none',
+                      boxShadow: 'none',
+                      background: 'none',
+                      lineHeight: 'inherit',
+                      verticalAlign: 'baseline',
+                      color: '#facc15',
+                      fontWeight: 'bold',
+                      cursor: 'help',
+                    }}
+                  >
+                    4
+                  </Button>
+                  ,{' '}
+                  <Button
+                    tooltip="Т5 - дает 27 слотов вещей, 15 скидочных триумфа, 120 слотов персонажей, возможность поменять цвет в дискорде, кастомную боевую музыку и вещи своего тира. Также дается возможность зайти за любую роль с повышенным приоритетом, в отличии от Т3 и Т4 каких-либо ограничений нет."
+                    tooltipPosition="bottom"
+                    style={{
+                      minWidth: '0',
+                      width: 'auto',
+                      height: 'auto',
+                      padding: '0',
+                      border: 'none',
+                      boxShadow: 'none',
+                      background: 'none',
+                      lineHeight: 'inherit',
+                      verticalAlign: 'baseline',
+                      color: '#facc15',
+                      fontWeight: 'bold',
+                      cursor: 'help',
+                    }}
+                  >
+                    5
+                  </Button>
+                  ) открываются различные бонусы в лодауте и не только. Лишь за
+                  счет поддержки сервер существует.
+                </Box>
               </Stack.Item>
               <br />
               <Stack.Item>
@@ -139,8 +277,8 @@ export const LoadoutPanel = () => {
                 <Box
                   mt={2}
                   style={{
-                    minHeight: '180px',
-                    maxHeight: '200px',
+                    minHeight: '200px',
+                    maxHeight: '260px',
                     overflowY: 'auto',
                     overflowX: 'hidden',
                     padding: '8px',

--- a/tgui/packages/tgui/interfaces/LoadoutPanel.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useBackend } from 'tgui/backend';
+import { classes } from 'tgui-core/react';
 import { Window } from 'tgui/layouts';
 import {
   DmIcon,
@@ -15,6 +16,7 @@ import {
 interface Data {
   categories: Record<string, Record<string, Item>>;
   isDonator: boolean | number;
+  selectedLoadoutItems: string[];
   donatTier: number;
   triumphDiscount: number;
   triumphDiscountUsed: number;
@@ -25,10 +27,10 @@ interface Data {
 interface Item {
   name: string;
   path: string;
+  icon_class_name: string;
   isDonatorItem: boolean;
   icon: string;
   icon_state: string;
-  isSelected: boolean;
   unavailable?: boolean;
   unavailableReason?: string;
   requiredTier?: number;
@@ -41,28 +43,14 @@ export const LoadoutPanel = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [confirmReset, setConfirmReset] = useState(false);
 
+  const selectedSet = new Set(data.selectedLoadoutItems ?? []);
+
   const categoriesArray = Object.entries(data.categories ?? {}).map(
     ([name, items]) => ({
       name,
       items,
     })
   );
-
-  const fallback = <Icon m="32px" name="spinner" spin />;
-
-  const easter = [
-    'Сделано Авфулом',
-    'Внимание!!! ПСАЙДОН СДОХ',
-    'АБЫРВАЛГ',
-    'Нок сила!',
-    'Нок и Зизо подружки лесбушки',
-    'Нажмешь на кнопку еще раз и я зафоршу тебе расу на кошкодевку',
-    '\u0421\u043c\u0430\u0439\u043b\u0438\u0020\u043b\u043e\u0448\u0430\u0440\u0430',
-    '\u0420\u0435\u0434\u043c\u0443\u043d\u0020\u0438\u0020\u0431\u043b\u044e\u043c\u0443\u043d\u0020\u0433\u043e\u0432\u043d\u043e',
-    '\u0411\u041b\u042f\u0020\u042f\u0020\u041d\u0415\u041d\u0410\u0412\u0418\u0416\u0423\u0020\u0424\u0423\u0420\u0420\u0418',
-  ];
-
-  const [authored, setAuthored] = useState(easter[0]);
 
   const filteredItems = Object.values(categoriesArray[tabIndex]?.items || {}).filter(
     (item) => (item?.name?.toLowerCase() || '').includes(searchQuery.toLowerCase())
@@ -89,238 +77,217 @@ export const LoadoutPanel = () => {
   return (
     <Window title="Лодаут" width={1000} height={700}>
       <Window.Content>
-        <Box style={{ position: 'absolute', width: '300px', height: '200px' }}>
-          <Box
-            style={{
-              position: 'absolute',
-              top: '0',
-              userSelect: 'none',
-              left: '0',
-              fontSize: '12px',
-              fontWeight: 'bold',
-              padding: '4px',
-            }}
-            onClick={() => setAuthored(easter[Math.floor(Math.random() * easter.length)])}
-          >
-            {authored}
-          </Box>
-        </Box>
-        <Stack vertical fill textAlign="center">
-          <Stack.Item>
-            <h2>Выберите предметы для вашего персонажа.</h2>
-          </Stack.Item>
-          <Stack.Item>
-            <h2>
-              Вы их сможете забрать, когда нажмете правой кнопкой мыши по статуе
-              или дереву.
-            </h2>
-          </Stack.Item>
-          <Stack.Item>
-            <h4>
-              Рескины на оружие (Donator kit) являются просто рескинами, чтобы
-              его получить используйте зелье на соответствующем предмете.
-            </h4>
-          </Stack.Item>
-          <Stack.Item>
-            <Button onClick={() => act('boosty')}>
-              <h3>Поддержать сервер</h3>
-            </Button>
-          </Stack.Item>
-          <br />
-          <Stack.Item>
-            {data.curLoadoutSlots} / {data.maxLoadoutSlots}
-          </Stack.Item>
-          <Stack.Item>
-            <ProgressBar
-              ranges={{
-                bad: [0.75, Infinity],
-                average: [0.25, 0.75],
-                good: [-Infinity, 0.25],
-              }}
-              value={slotRatio}
-              width="300px"
-            />
-          </Stack.Item>
+        <Stack fill>
+          <Stack.Item width="300px">
+            <Stack vertical textAlign="justify">
+              <Stack.Item>
+                <h2>Выберите предметы для вашего персонажа.</h2>
+              </Stack.Item>
+              <Stack.Item>
+                <h2>
+                  Вы их сможете забрать, когда нажмете правой кнопкой мыши по статуе
+                  или дереву.
+                </h2>
+              </Stack.Item>
+              <Stack.Item>
+                <h4>
+                  Рескины на оружие (Donator kit) являются просто рескинами, чтобы
+                  его получить используйте зелье на соответствующем предмете.
+                </h4>
+              </Stack.Item>
+              <Stack.Item>
+                <Button onClick={() => act('boosty')}>
+                  <h3>Поддержать сервер</h3>
+                </Button>
+              </Stack.Item>
+              <br />
+              <Stack.Item>
+                {data.curLoadoutSlots} / {data.maxLoadoutSlots}
+              </Stack.Item>
+              <Stack.Item>
+                <ProgressBar
+                  ranges={{
+                    bad: [0.75, Infinity],
+                    average: [0.25, 0.75],
+                    good: [-Infinity, 0.25],
+                  }}
+                  value={slotRatio}
+                  width="300px"
+                />
+              </Stack.Item>
 
-          {hasDonatorTriumphDiscount ? (
-            <Stack.Item>
-              <Box
-                style={{
-                  display: 'inline-block',
-                  padding: '8px 14px',
-                  borderRadius: '8px',
-                  backgroundColor: 'rgba(212, 175, 55, 0.14)',
-                  border: '1px solid rgba(212, 175, 55, 0.55)',
-                  color: '#facc15',
-                  fontWeight: 'bold',
-                  textShadow: '1px 1px 3px rgba(0,0,0,0.75)',
-                }}
-              >
-                ★ Скидочные триумфы: занято {data.triumphDiscountUsed} из{' '}
-                {data.triumphDiscount}
-              </Box>
-            </Stack.Item>
-          ) : null}
-
-          <Stack.Item
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginTop: '10px',
-            }}
-          >
-            <Input
-              placeholder="Поиск предметов..."
-              value={searchQuery}
-              onChange={setSearchQuery}
-              width="300px"
-            />
-            <Button
-              onClick={handleResetClick}
-              style={{ marginTop: '10px' }}
-              color={confirmReset ? 'good' : 'danger'}
-            >
-              <span style={{ color: 'white' }}>
-                {confirmReset ? 'Точно?' : 'Сбросить все'}
-              </span>
-            </Button>
-          </Stack.Item>
-          <Stack.Item>
-            <Tabs>
-              {categoriesArray.map((cat, i) => (
-                <Tabs.Tab
-                  key={cat.name}
-                  selected={i === tabIndex}
-                  onClick={() => setTabIndex(i)}
-                  style={{
-                    flex: 1,
-                    backgroundColor: i === tabIndex ? '#444' : '#222',
-                    color: 'white',
-                  }}
-                >
-                  {cat.name}
-                </Tabs.Tab>
-              ))}
-            </Tabs>
-          </Stack.Item>
-          <Stack.Item
-            style={{
-              overflow: 'auto',
-            }}
-          >
-            {filteredItems.map((item, index) => (
-              <div
-                key={item?.name || item?.path || index}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  padding: '8px',
-                  minHeight: '64px',
-                  backgroundColor: index % 2 === 0 ? '#2e2e2e' : '#1c1c1c',
-                  borderRadius: '4px',
-                  marginBottom: '4px',
-                }}
-              >
-                <Box
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    minWidth: '112px',
-                    marginRight: '12px',
-                    flexShrink: 0,
-                  }}
-                >
-                  <DmIcon
-                    icon={item?.icon}
-                    fallback={fallback}
-                    icon_state={item?.icon_state}
-                    style={{
-                      backgroundColor: '#141414',
-                      borderRadius: '12px',
-                      padding: '16px',
-                      width: '96px',
-                      height: '96px',
-                    }}
-                  />
-                  {item?.triumphCost ? (
-                    <Box
-                      style={{
-                        marginTop: '6px',
-                        width: '96px',
-                        fontSize: '12px',
-                        fontWeight: 'bold',
-                        color: '#d4af37',
-                        textAlign: 'center',
-                        textShadow: '1px 1px 3px rgba(0,0,0,0.75)',
-                        lineHeight: 1.2,
-                      }}
-                    >
-                      {item.triumphCost} триумфов
-                    </Box>
-                  ) : null}
-                  {item?.isDonatorItem ? (
-                    <Box
-                      style={{
-                        marginTop: '4px',
-                        width: '96px',
-                        fontSize: '12px',
-                        fontWeight: 'bold',
-                        color: '#c084fc',
-                        textAlign: 'center',
-                        textShadow: '1px 1px 3px rgba(0,0,0,0.75)',
-                        lineHeight: 1.2,
-                      }}
-                    >
-                      Донат тир {item.requiredTier && item.requiredTier > 0 ? item.requiredTier : 1}
-                    </Box>
-                  ) : null}
-                </Box>
-                <blockquote
-                  style={{
-                    margin: 0,
-                    flexGrow: 1,
-                    fontSize: '18px',
-                    color: '#e4e4e4',
-                    textShadow: '2px 2px 4px rgba(0,0,0,0.5)',
-                  }}
-                >
-                  {item?.name || 'Без названия'}
-                </blockquote>
-                {item?.unavailable ? (
-                  <Box style={{ color: 'red', maxWidth: '220px' }}>
-                    {item?.unavailableReason ||
-                      (item?.requiredTier
-                        ? `Недоступно. Требуется уровень: ${item.requiredTier}`
-                        : 'Недоступно.')}
-                  </Box>
-                ) : (
+              {hasDonatorTriumphDiscount ? (
+                <Stack.Item>
                   <Box
                     style={{
-                      width: 96,
-                      height: 96,
-                      backgroundColor: item?.isSelected ? '#a71818' : '#24a718',
-                      borderRadius: 8,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      color: '#000',
-                    }}
-                    onClick={() => {
-                      if (item?.isSelected) {
-                        act('remove', { item: item?.name || item?.path });
-                      } else {
-                        act('add', { item: item?.name || item?.path });
-                      }
+                      display: 'inline-block',
+                      padding: '8px 14px',
+                      borderRadius: '8px',
+                      backgroundColor: 'rgba(212, 175, 55, 0.14)',
+                      border: '1px solid rgba(212, 175, 55, 0.55)',
+                      color: '#facc15',
+                      fontWeight: 'bold',
+                      textShadow: '1px 1px 3px rgba(0,0,0,0.75)',
                     }}
                   >
-                    <b>{item?.isSelected ? 'Убрать' : 'Взять'}</b>
+                    ★ Скидочные триумфы: занято {data.triumphDiscountUsed} из{' '}
+                    {data.triumphDiscount}
                   </Box>
-                )}
-              </div>
-            ))}
+                </Stack.Item>
+              ) : null}
+            </Stack>
+          </Stack.Item>
+
+          <Stack.Item width="100%">
+            <Stack vertical fill>
+              <Stack.Item>
+                <Tabs>
+                  {categoriesArray.map((cat, i) => (
+                    <Tabs.Tab
+                      key={cat.name}
+                      selected={i === tabIndex}
+                      onClick={() => setTabIndex(i)}
+                      style={{
+                        flex: 1,
+                        backgroundColor: i === tabIndex ? '#444' : '#222',
+                        color: 'white',
+                      }}
+                    >
+                      {cat.name}
+                    </Tabs.Tab>
+                  ))}
+                </Tabs>
+              </Stack.Item>
+              <Stack.Item
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginTop: '10px',
+                }}
+              >
+                <Input
+                  placeholder="Поиск предметов..."
+                  value={searchQuery}
+                  onChange={setSearchQuery}
+                  width="300px"
+                />
+                <Button
+                  onClick={handleResetClick}
+                  style={{ marginTop: '10px' }}
+                  color={confirmReset ? 'good' : 'danger'}
+                >
+                  <span style={{ color: 'white' }}>
+                    {confirmReset ? 'Точно?' : 'Сбросить все'}
+                  </span>
+                </Button>
+              </Stack.Item>
+              <Stack.Item
+                style={{
+                  overflowY: 'auto',
+                  overflowX: 'hidden',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(96px, 1fr))',
+                    gap: '8px',
+                  }}
+                >
+                {filteredItems.map((item, index) => (
+                  <div
+                    key={item?.name || item?.path || index}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      minHeight: '64px',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    <Box
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        minWidth: '96px',
+                        flexShrink: 0,
+                      }}
+                    >
+                      <Button
+                        style={{
+                          backgroundColor: '#141414',
+                          padding: '16px',
+                          width: '96px',
+                          height: '96px',
+                          border: '2x solid red',
+                          borderColor: `${item?.unavailable ? '#a77a18' : (selectedSet.has(item?.name)? '#a71818' : '#24a718')}`,
+                          borderRadius: '8px',
+                        }}
+                        tooltip={
+                          `${item?.unavailable 
+                              ? item?.unavailableReason || (item?.requiredTier ? "Недоступно. Требуется уровень:"+item.requiredTier : 'Недоступно.') 
+                              : item?.name || 'Без названия'}`}
+                        onClick={() => {
+                          if (selectedSet.has(item?.name)) {
+                            act('remove', { item: item?.name || item?.path });
+                          } else {
+                            act('add', { item: item?.name || item?.path });
+                          }
+                        }}
+                      >
+                        <Box
+                          inline
+                          verticalAlign="middle"
+                          className={item.icon_class_name}
+                          style={{
+                            transform: 'scale(0.67) translate(-51px, -50px)',
+                          }}
+                        >
+                            {item?.triumphCost ? (
+                              <Box
+                                style={{
+                                  width: '100%',
+                                  marginTop: '96px',
+                                  fontSize: '20px',
+                                  fontWeight: 'bold',
+                                  color: '#d4af37',
+                                  outlineColor: 'black',
+                                  textAlign: 'center',
+                                  textShadow: '1px 1px 3px rgba(0,0,0,0.75)',
+                                  lineHeight: 1.2,
+                                }}
+                              >
+                                {item.triumphCost} триумфов
+                              </Box>
+                            ) : null}
+
+                            {item?.isDonatorItem ? (
+                              <Box
+                                style={{
+                                  width: '100%',
+                                  marginTop: '96px',
+                                  fontSize: '20px',
+                                  fontWeight: 'bold',
+                                  color: '#c084fc',
+                                  outlineColor: 'black',
+                                  textAlign: 'center',
+                                  textShadow: '1px 1px 3px rgba(0,0,0,0.75)',
+                                  lineHeight: 1.2,
+                                }}
+                              >
+                                Донат тир {item.requiredTier && item.requiredTier > 0 ? item.requiredTier : 1}
+                              </Box>
+                            ) : null}
+                        </Box>
+                      </Button>
+                    </Box>
+                  </div>
+                ))}
+                </div>
+              </Stack.Item>
+            </Stack>
           </Stack.Item>
         </Stack>
       </Window.Content>


### PR DESCRIPTION
## About The Pull Request

Авфул сделал новое меню, а я доделал пару штук, ибо у него времени еще меньше чем у меня.
Новое меню теперь не зависает при открытии и более компактное.  Теперь видны лишь картинки, а названия предметов показываются при наведении.

## Testing Evidence

<img width="1210" height="725" alt="image" src="https://github.com/user-attachments/assets/4fb20553-091c-47b8-9e52-df7d9da4bd19" />


## Why It's Good For The Game

Более компактное и не лагающее меню это круто

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Лодаут меню было переработано и сделано более компактным
fix: Исправлены лаги при открытии лодаута
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
