### PR TITLE
trollslayer buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
@@ -13,7 +13,7 @@
 		STATKEY_STR = 2, 
 		STATKEY_CON = 5,
 		STATKEY_WIL = 2,
-		STATKEY_INT = -3,
+		STATKEY_INT = -3, // Brain dented in an accident involving 2 squirrels and a drunk zizite.
 		STATKEY_SPD = -1,
 		STATKEY_PER = -1
 	)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
@@ -13,7 +13,6 @@
 		STATKEY_STR = 2, 
 		STATKEY_CON = 5,
 		STATKEY_WIL = 2,
-		STATKEY_INT = -3, // Brain dented in an accident involving 2 squirrels and a drunk zizite.
 		STATKEY_SPD = -1,
 		STATKEY_PER = -1
 	)
@@ -23,6 +22,7 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/labor/butchering = SKILL_LEVEL_JOURNEYMAN, // Butcher trolls
@@ -134,7 +134,7 @@
 		/datum/species/dwarf/mountain
 		)
 	surgery_cover = FALSE 
-	max_integrity = 135
+	max_integrity = 325 
 	sewrepair = FALSE
 	repairmsg_begin = "The thick skin cover starts to bulge and repair tears"
 	repairmsg_continue = "More of the tears on the skin close up"
@@ -142,7 +142,7 @@
 	repairmsg_end = "Your skin looks just as shiny as ever, like it might stop the blow of a fully grown troll once more."
 
 	interrupt_damount = 25
-	repair_time = 35 SECONDS
+	repair_time = 30 SECONDS
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/slayer/Initialize(mapload)
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/slayer.dm
@@ -13,6 +13,7 @@
 		STATKEY_STR = 2, 
 		STATKEY_CON = 5,
 		STATKEY_WIL = 2,
+		STATKEY_INT = -3,
 		STATKEY_SPD = -1,
 		STATKEY_PER = -1
 	)


### PR DESCRIPTION
## About The Pull Request

Ныне класс наемника "Истребитель троллей" сильно уступает своим товарищам по делу. Очень обидно, что такой действительно проработанный наемник просто пылится на полке из-за банального отсутствия нормальной брони и статов. Единственное, что его хоть как-то спасает - скилл, но и то не всегда. Убить кого-то за 30 секунд вряд ли получится, а если слишком долго откладывать прожатие и того смерть. Поэтому  этот бафф сделает его более опасным противником, что способен противостоять нынешним антагам и прочим. 

## Testing Evidence

Проверенно на локалке 

## Why It's Good For The Game

 Многие хотят почувствовать себя безбашенным берсерком, что готов через боль нести хаос и страх своим врагам

## Changelog

:cl:
add: навык чтения
balance: ребаланс брони и статов
/:cl: