### PR TITLE
1 слот отаванскому волку

### DIFF
--- a/modular_twilight_axis/code/modules/jobs/job_types/roguetown/Inquisition/orthodoxist.dm
+++ b/modular_twilight_axis/code/modules/jobs/job_types/roguetown/Inquisition/orthodoxist.dm
@@ -2,6 +2,7 @@
 	job_traits += list(TRAIT_OUTLANDER)
 	job_subclasses += list(
 		/datum/advclass/blackpowder_legionnaire,
-		/datum/advclass/psydonianwarscholar
+		/datum/advclass/psydonianwarscholar,
+		/datum/advclass/otavan_volf
 		)
 	. = ..()

--- a/modular_twilight_axis/code/modules/spell/spell_types/wizard/misc/shadowstep.dm
+++ b/modular_twilight_axis/code/modules/spell/spell_types/wizard/misc/shadowstep.dm
@@ -13,7 +13,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	chargedrain = 1
 	chargetime = 0 SECONDS
-	recharge_time = 20 SECONDS
+	recharge_time = 30 SECONDS
 	hide_charge_effect = TRUE
 	gesture_required = TRUE // Mobility spell
 	spell_tier = 2

--- a/modular_twilight_axis/firearms/code/jobs/orthodoxist.dm
+++ b/modular_twilight_axis/firearms/code/jobs/orthodoxist.dm
@@ -278,9 +278,102 @@
 	cmode_music = 'modular_twilight_axis/firearms/sound/music/combat_blackpowder.ogg'
 	category_tags = list(CTAG_ORTHODOXIST)
 	traits_applied = list(TRAIT_PSYDONITE, TRAIT_ARTILLERY_EXPERT)
-	classes = list("Legionnaire" = "Soldier of the Last War. Bring your deadly weapon of blackpowder to the battlefield", 
-	"Otavan Volf" = "No matter who you were before. Now you are a bloodhound of Inquisition enchanted with rune magyck. \
-	No doors can stop you and no heretic can escape your silent bullet.")
+	subclass_stats = list(
+		STATKEY_PER = 3,
+		STATKEY_WIL = 2,
+		STATKEY_CON = 1,
+		STATKEY_INT = 1,
+		STATKEY_SPD = 1
+	)
+	subclass_skills = list(
+		/datum/skill/combat/twilight_firearms = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE
+	)
+	subclass_stashed_items = list(
+		"Tome of Psydon" = /obj/item/book/rogue/bibble/psy
+	)
+	extra_context = "This subclass can choose between light or medium armor. The Legionnaire wields powerful blackpowder weapons and gains either Dodge Expert or Maille Training."
+
+/datum/outfit/job/roguetown/blackpowder_legionnaire
+	job_bitflag = BITFLAG_HOLY_WARRIOR
+
+/datum/outfit/job/roguetown/blackpowder_legionnaire/pre_equip(mob/living/carbon/human/H, visualsOnly)
+	..()
+	backl = /obj/item/storage/backpack/rogue/satchel/otavan
+	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
+	cloak = /obj/item/clothing/cloak/bandolier
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/inq
+	neck = /obj/item/clothing/neck/roguetown/leather/blackpowder
+	gloves = /obj/item/clothing/gloves/roguetown/chain/psydon
+	mask = /obj/item/clothing/mask/rogue/facemask/steel/confessor
+	id = /obj/item/clothing/ring/signet/psy
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
+
+	var/weapons = list("Purgatory (Handcannon)", "Runelock Pistol")
+	var/weapon_choice = input(H,"Choose your WEAPON.", "TAKE UP PSYDON'S ARMS.") as anything in weapons
+	switch(weapon_choice)
+		if("Purgatory (Handcannon)")
+			belt = /obj/item/storage/belt/rogue/leather/black
+			l_hand = /obj/item/gun/ballistic/twilight_firearm/handgonne/purgatory
+			backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,
+			/obj/item/paper/inqslip/arrival/ortho = 1,
+			/obj/item/twilight_powderflask/holyfyre = 1,
+			/obj/item/natural/bundle/fibers/full = 1,
+			/obj/item/storage/belt/rogue/pouch/coins/mid = 1)
+			var/quivers = list("Grapeshot", "Cannonballs")
+			var/ammochoice = input(H,"Choose your MUNITIONS.", "TAKE UP PSYDON'S MISSILES.") as anything in quivers
+			switch(ammochoice)
+				if("Grapeshot")
+					beltr = /obj/item/quiver/twilight_bullet/cannonball/grapeshot
+				if("Cannonballs")
+					beltr = /obj/item/quiver/twilight_bullet/cannonball/lead
+		if("Runelock Pistol")
+			belt = /obj/item/storage/belt/rogue/leather/twilight_holsterbelt/blackpowder
+			beltr = /obj/item/quiver/twilight_bullet/runicbag/runed
+			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/twilight_runelock
+			backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,
+			/obj/item/paper/inqslip/arrival/ortho = 1,
+			/obj/item/storage/belt/rogue/pouch/coins/mid = 1)
+
+	var/armors = list("Medium Armor", "Light Armor")
+	var/armor_choice = input(H, "Choose your ARMOR.", "TAKE UP PSYDON'S MANTLE.") as anything in armors
+	switch(armor_choice)
+		if("Medium Armor")
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/ornate
+			pants = /obj/item/clothing/under/roguetown/chainlegs
+			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+		if("Light Armor")
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fencer/psydon
+			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
+			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+
+	head = /obj/item/clothing/head/roguetown/helmet/kettle
+	wrists = /obj/item/clothing/neck/roguetown/psicross/silver
+	beltl = /obj/item/rogueweapon/scabbard/sword
+	r_hand = /obj/item/rogueweapon/sword/short/psy
+
+/datum/advclass/otavan_volf
+	name = "Otavan Volf"
+	tutorial = "No matter who you were before. Now you are a bloodhound of Inquisition enchanted with rune magyck. No doors can stop you and no heretic can escape your silent bullet."
+	allowed_sexes = list(MALE, FEMALE)
+	outfit = /datum/outfit/job/roguetown/otavan_volf
+	subclass_languages = list(/datum/language/otavan)
+	cmode_music = 'modular_twilight_axis/firearms/sound/music/combat_blackpowder.ogg'
+	category_tags = list(CTAG_ORTHODOXIST)
+	traits_applied = list(TRAIT_PSYDONITE, TRAIT_BLACKBAGGER)
+	maximum_possible_slots = 1
 	subclass_stats = list(
 		STATKEY_PER = 3,
 		STATKEY_WIL = 2,
@@ -300,17 +393,20 @@
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE
+		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
+		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_EXPERT
+
 	)
 	subclass_stashed_items = list(
 		"Tome of Psydon" = /obj/item/book/rogue/bibble/psy
 	)
-	extra_context = "This subclass can choose between two archetypes: Legionnaire and Otavan Volf. Legionnaire wield powerful blackpowder weapons and may select between light or medium armor, gaining Dodge Expert or Maille Training respectively. Otavan Volf specialize in stealth, rune magyck and silent firearms."
+	extra_context = "The Otavan Volf is a silent killer of the Inquisition, using stealth, rune magyck and a silenced firearm. Choose between psydonic claws or a silver dagger."
 
-/datum/outfit/job/roguetown/blackpowder_legionnaire
+/datum/outfit/job/roguetown/otavan_volf
 	job_bitflag = BITFLAG_HOLY_WARRIOR
 
-/datum/outfit/job/roguetown/blackpowder_legionnaire/pre_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/job/roguetown/otavan_volf/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
 	backl = /obj/item/storage/backpack/rogue/satchel/otavan
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
@@ -322,89 +418,41 @@
 	id = /obj/item/clothing/ring/signet/psy
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
-	var/classes = list("Legionnaire", "Otavan Volf")
-	var/classchoice = input(H, "Choose your archetypes", "Available archetypes") as anything in classes
-	
-	if(H.mind)
-		switch(classchoice)
-			if("Legionnaire")
-				var/weapons = list("Purgatory (Handcannon)", "Runelock Pistol")
-				var/weapon_choice = input(H,"Choose your WEAPON.", "TAKE UP PSYDON'S ARMS.") as anything in weapons
-				switch(weapon_choice)
-					if("Purgatory (Handcannon)")
-						belt = /obj/item/storage/belt/rogue/leather/black
-						l_hand = /obj/item/gun/ballistic/twilight_firearm/handgonne/purgatory
-						backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,
-						/obj/item/paper/inqslip/arrival/ortho = 1,
-						/obj/item/twilight_powderflask/holyfyre = 1,
-						/obj/item/natural/bundle/fibers/full = 1,
-						/obj/item/storage/belt/rogue/pouch/coins/mid = 1)
-						var/quivers = list("Grapeshot", "Cannonballs")
-						var/ammochoice = input(H,"Choose your MUNITIONS.", "TAKE UP PSYDON'S MISSILES.") as anything in quivers
-						switch(ammochoice)
-							if("Grapeshot")
-								beltr = /obj/item/quiver/twilight_bullet/cannonball/grapeshot
-							if("Cannonballs")
-								beltr = /obj/item/quiver/twilight_bullet/cannonball/lead
-					if("Runelock Pistol")
-						belt = /obj/item/storage/belt/rogue/leather/twilight_holsterbelt/blackpowder
-						beltr = /obj/item/quiver/twilight_bullet/runicbag/runed
-						l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/twilight_runelock
-						backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,
-						/obj/item/paper/inqslip/arrival/ortho = 1,
-						/obj/item/storage/belt/rogue/pouch/coins/mid = 1)
-				var/armors = list("Medium Armor", "Light Armor")
-				var/armor_choice = input(H, "Choose your ARMOR.", "TAKE UP PSYDON'S MANTLE.") as anything in armors
-				switch(armor_choice)
-					if("Medium Armor")
-						armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted/ornate
-						pants = /obj/item/clothing/under/roguetown/chainlegs
-						ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-					if("Light Armor")
-						armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fencer/psydon
-						pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
-						ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-				head = /obj/item/clothing/head/roguetown/helmet/kettle
-				wrists = /obj/item/clothing/neck/roguetown/psicross/silver
-				beltl = /obj/item/rogueweapon/scabbard/sword
-				r_hand = /obj/item/rogueweapon/sword/short/psy
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			if ("Otavan Volf")
-				ADD_TRAIT(H, TRAIT_BLACKBAGGER, TRAIT_GENERIC)
-				var/weapons = list("Dagger", "Claws")
-				var/weapon_choice = input(H,"Choose your WEAPON.", "TAKE UP PSYDON'S ARMS.") as anything in weapons
-				switch(weapon_choice)
-					if("Dagger")
-						r_hand = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger
-						beltl = /obj/item/rogueweapon/scabbard/sheath
-						H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
-					if("Claws")
-						r_hand = /obj/item/rogueweapon/handclaw/gronn/silver/psy
-						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
-				wrists = /obj/item/clothing/neck/roguetown/psicross/silver
-				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/confessor
-				l_hand = /obj/item/gun/ballistic/twilight_firearm/arquebus_pistol/umbra
-				head = /obj/item/clothing/head/roguetown/roguehood/psydon/confessor
-				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
-				belt = /obj/item/storage/belt/rogue/leather/twilight_holsterbelt/blackpowder
-				beltr = /obj/item/quiver/twilight_bullet/lead
-				backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,
-					/obj/item/paper/inqslip/arrival/ortho = 1,
-					/obj/item/twilight_powderflask/volf = 1,
-					/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
-					/obj/item/inqarticles/garrote = 1,
-					/obj/item/clothing/head/inqarticles/blackbag = 1)
-				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_APPRENTICE, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, SKILL_LEVEL_EXPERT, TRUE)
-				H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/shadowstep)
-				H.mind?.AddSpell(new /obj/effect/proc_holder/spell/self/invisibility/runed)
-				H.mind?.RemoveSpell(H.mind.get_spell(/datum/action/cooldown/spell/touch/prestidigitation))
-				var/arcane = list("Fetch", "Repulse", "Leap")
-				var/arcane_choice = input("TAKE YOUR RUNE.", "PSYDON'S RUNE.") as anything in arcane
-				switch(arcane_choice)
-					if("Fetch")
-						H.mind?.AddSpell(new /datum/action/cooldown/spell/projectile/fetch)
-					if("Repulse")
-						H.mind?.AddSpell(new /datum/action/cooldown/spell/repulse)
-					if("Leap")
-						H.mind?.AddSpell(new /datum/action/cooldown/spell/leap)
+
+	var/weapons = list("Dagger", "Claws")
+	var/weapon_choice = input(H,"Choose your WEAPON.", "TAKE UP PSYDON'S ARMS.") as anything in weapons
+	switch(weapon_choice)
+		if("Dagger")
+			r_hand = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger
+			beltl = /obj/item/rogueweapon/scabbard/sheath
+			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
+		if("Claws")
+			r_hand = /obj/item/rogueweapon/handclaw/gronn/silver/psy
+			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+
+	wrists = /obj/item/clothing/neck/roguetown/psicross/silver
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/confessor
+	l_hand = /obj/item/gun/ballistic/twilight_firearm/arquebus_pistol/umbra
+	head = /obj/item/clothing/head/roguetown/roguehood/psydon/confessor
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
+	belt = /obj/item/storage/belt/rogue/leather/twilight_holsterbelt/blackpowder
+	beltr = /obj/item/quiver/twilight_bullet/lead
+	backpack_contents = list(/obj/item/roguekey/inquisitionmanor = 1,
+		/obj/item/paper/inqslip/arrival/ortho = 1,
+		/obj/item/twilight_powderflask/volf = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
+		/obj/item/inqarticles/garrote = 1,
+		/obj/item/clothing/head/inqarticles/blackbag = 1)
+
+	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/shadowstep)
+	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/self/invisibility/runed)
+	H.mind?.RemoveSpell(H.mind.get_spell(/datum/action/cooldown/spell/touch/prestidigitation))
+	var/arcane = list("Fetch", "Repulse", "Leap")
+	var/arcane_choice = input("TAKE YOUR RUNE.", "PSYDON'S RUNE.") as anything in arcane
+	switch(arcane_choice)
+		if("Fetch")
+			H.mind?.AddSpell(new /datum/action/cooldown/spell/projectile/fetch)
+		if("Repulse")
+			H.mind?.AddSpell(new /datum/action/cooldown/spell/repulse)
+		if("Leap")
+			H.mind?.AddSpell(new /datum/action/cooldown/spell/leap)


### PR DESCRIPTION
## About The Pull Request

Отаванский волк был перемещен в отдельный сабкласс и был ограничен 1 слотом.

По сравнению с ортодоксом с огнестрелом волк выглядит весьма мощно из-за 3 заклинаний, от чего инквизиция его очень часто берет, порой полностью забивая ими слоты ортодоксов. 

## Testing Evidence

На локалке работает.
<img width="318" height="223" alt="image" src="https://github.com/user-attachments/assets/6c49b4ce-6d97-4c38-8e9e-4fb023fb17d7" />



## Why It's Good For The Game

Инквизиция щас и так вполне себе мощная, имея кучу уникальных классов. Я не думаю, что она сильно пострадает, если у отаванского волка будет ограничение на 1 слот.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: ограничение на 1 слот для отаванского волка
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
