### PR TITLE
[абсолютно модульно] уборка кансера у ликеров

### DIFF
--- a/modular_twilight_axis/code/modules/vampire_neu/TA_Vampires_include.dm
+++ b/modular_twilight_axis/code/modules/vampire_neu/TA_Vampires_include.dm
@@ -39,6 +39,6 @@
 #include "./overrides/vampire_lord_title.dm"
 #include "./overrides/crucible_access.dm"
 #include "./overrides/thinblood_restrictions.dm"
-
+#include "./overrides/obfuscate.dm"
 // Local defines
 #include "./TA_Vampires_uniclude.dm"

--- a/modular_twilight_axis/code/modules/vampire_neu/overrides/obfuscate.dm
+++ b/modular_twilight_axis/code/modules/vampire_neu/overrides/obfuscate.dm
@@ -1,0 +1,26 @@
+/datum/coven_power/obfuscate/vanish_from_the_minds_eye
+    parent_type = /datum/coven_power/obfuscate // 200 iq trick, don't remove. Trust me bro. Or we'll get duplicate def errors.
+
+/datum/coven_power/obfuscate/vanish_from_the_minds_eye
+    name = "Enhanced Unseen Presence"
+    desc = "Disappear from plain view instantly while slowing and blinding your foes"
+    level = 3
+    research_cost = 2
+    parent_type = /datum/coven_power/obfuscate/unseen_presence
+    vitae_cost = parent_type::vitae_cost + 10
+    COOLDOWN_DECLARE(effect_cooldown)
+
+/datum/coven_power/obfuscate/vanish_from_the_minds_eye/activate()
+    . = ..()
+
+    if(!COOLDOWN_FINISHED(src, effect_cooldown))
+        return
+
+    for(var/mob/living/carbon/human/viewer in oviewers(7, owner))
+        if(!viewer.client || viewer.stat || viewer.mob_biotypes & MOB_UNDEAD)
+            continue
+
+        viewer.Slowdown(3)
+        viewer.blind_eyes(1)
+
+    COOLDOWN_START(src, effect_cooldown, 30 SECONDS)


### PR DESCRIPTION
## About The Pull Request
давно хотел это изменить, но руки не доходили пока не увидел очередную драму из-за этого хрп спелла в дискордике

теперь т3 обфуз не забывайка, а такой же как т2 обфуз, всегда будет стоить на 10 витае больше него, но взамен дает аое замедло на 3 сек + 1 сек блайнда при активации (эффекты имеют кд 30  сек, кулдаун обфуза не затронут). Это пиздец уныло, можно придумать что то получше, но пока так

## Testing Evidence
т.к я вместо тупого копирования кода активейта/диактивейта/сигнального прибегнул к 200 айкью стратегии через 2 оверрайда parent_type (отнаследовать по человечески не вариант ибо пришлось бы лезть в кор, а два нужно т.к прок хендл мув был и у ансин презенса и у забывайки и мы бы просто получали дупликат еррор), то уйти далеко на траст ми бро не получилось бы

<img width="353" height="199" alt="Zrzut ekranu 2026-07-16 180639" src="https://github.com/user-attachments/assets/4771aa22-9a01-485b-b9d3-8cf7346709b0" />

венардиггер выдал крутую распальцовку и эпично испарился
<img width="1757" height="911" alt="Zrzut ekranu 2026-07-16 180655" src="https://github.com/user-attachments/assets/7143fd27-d5e0-4662-840d-3b2d5a40cd8d" />

также работают сигнальные проки
<img width="458" height="39" alt="Zrzut ekranu 2026-07-16 180711" src="https://github.com/user-attachments/assets/7cbb0151-4eab-48a7-8090-e749c6cc7cc1" />

на другого венардиггера слоудаун наложился, когда инитнул на нём клиент, но скрин чот не сохранился, короче мне можно верить


## Why It's Good For The Game
убирает дискорд драмы механом, а не скрытыми правилами, которые можно найти в https://discord.com/channels/1133928966915358822/1504384449788252190

## Changelog
:cl:
code: забывайка вампиров заменена на ансин презенс++
/:cl:
