### PR TITLE
Фикс бесконечных атак мобов по трупам/бессмертным целям

### DIFF
--- a/code/__DEFINES/ai/hostile.dm
+++ b/code/__DEFINES/ai/hostile.dm
@@ -15,6 +15,12 @@
 //Limit of how many enemies a unit can target through
 #define AI_MAX_ENEMIES 99
 
+// TA EDIT START
+#define AI_MELEE_NO_PROGRESS_LIMIT 20
+#define AI_MELEE_NO_PROGRESS_TIME (30 SECONDS)
+#define AI_MELEE_IGNORE_TIME (30 SECONDS)
+// TA EDIT END
+
 /// After either being given a verbal order or a pointing order, ignore further of each for this duration
 #define AI_HOSTILE_COMMAND_COOLDOWN (2 SECONDS)
 

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -638,7 +638,7 @@ have ways of interacting with a specific atom and control it. They posses a blac
 		return FALSE
 
 	var/mob/living/living_target = target
-	if(QDELETED(living_target) || living_target.stat == DEAD)
+	if(QDELETED(living_target))
 		reset_melee_attack_progress()
 		return FALSE
 

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -60,6 +60,16 @@ have ways of interacting with a specific atom and control it. They posses a blac
 	///AI paused time
 	var/paused_until = 0
 
+	// TA EDIT START
+	var/datum/weakref/melee_progress_target
+	var/melee_progress_health
+	var/melee_progress_stat
+	var/melee_progress_since
+	var/melee_no_progress_attacks
+	var/datum/weakref/ignored_melee_target
+	var/ignored_melee_target_until
+	// TA EDIT END
+
 	var/failed_sneak_check = 0
 	///Time at which controller became inactive
 	var/inactive_timestamp
@@ -605,6 +615,71 @@ have ways of interacting with a specific atom and control it. They posses a blac
 	// Kick the cooldown on target-acquisition behaviors so they fire on the next tick.
 	for(var/behavior_type in list(/datum/ai_behavior/find_potential_targets, /datum/ai_behavior/find_aggro_targets))
 		behavior_cooldowns[behavior_type] = world.time
+
+// TA EDIT START
+/datum/ai_controller/proc/reset_melee_attack_progress()
+	melee_progress_target = null
+	melee_progress_health = null
+	melee_progress_stat = null
+	melee_progress_since = 0
+	melee_no_progress_attacks = 0
+
+/datum/ai_controller/proc/is_melee_target_ignored(atom/target)
+	var/atom/ignored_target = ignored_melee_target?.resolve()
+	if(!ignored_target || world.time >= ignored_melee_target_until)
+		ignored_melee_target = null
+		ignored_melee_target_until = 0
+		return FALSE
+	return ignored_target == target
+
+/datum/ai_controller/proc/record_melee_attack_progress(atom/target, target_key, hiding_location_key)
+	if(!isliving(target))
+		reset_melee_attack_progress()
+		return FALSE
+
+	var/mob/living/living_target = target
+	if(QDELETED(living_target) || living_target.stat == DEAD)
+		reset_melee_attack_progress()
+		return FALSE
+
+	var/mob/living/tracked_target = melee_progress_target?.resolve()
+	if(tracked_target != living_target)
+		reset_melee_attack_progress()
+		melee_progress_target = WEAKREF(living_target)
+		melee_progress_health = living_target.health
+		melee_progress_stat = living_target.stat
+		melee_progress_since = world.time
+		melee_no_progress_attacks = 1
+		return FALSE
+
+	if(living_target.stat != melee_progress_stat || living_target.health < melee_progress_health)
+		melee_progress_health = living_target.health
+		melee_progress_stat = living_target.stat
+		melee_progress_since = world.time
+		melee_no_progress_attacks = 0
+		return FALSE
+
+	if(living_target.health > melee_progress_health)
+		melee_progress_health = living_target.health
+
+	melee_no_progress_attacks++
+	if(melee_no_progress_attacks < AI_MELEE_NO_PROGRESS_LIMIT || world.time < melee_progress_since + AI_MELEE_NO_PROGRESS_TIME)
+		return FALSE
+
+	ignored_melee_target = WEAKREF(living_target)
+	ignored_melee_target_until = world.time + AI_MELEE_IGNORE_TIME
+	reset_melee_attack_progress()
+
+	if(target_key && blackboard[target_key] == living_target)
+		clear_blackboard_key(target_key)
+	if(hiding_location_key && blackboard[hiding_location_key])
+		clear_blackboard_key(hiding_location_key)
+	if(blackboard[BB_HIGHEST_THREAT_MOB] == living_target)
+		clear_blackboard_key(BB_HIGHEST_THREAT_MOB)
+
+	nudge_target_scan()
+	return TRUE
+// TA EDIT END
 
 /proc/alert_ai_visibility_change(atom/source, range = 7)
 	for(var/mob/living/L in view(range, source))

--- a/code/datums/ai/behaviors/hostile/melee_attack.dm
+++ b/code/datums/ai/behaviors/hostile/melee_attack.dm
@@ -27,7 +27,7 @@
 	var/atom/target = controller.blackboard[target_key]
 	var/datum/targetting_datum/targetting_datum = controller.blackboard[targetting_datum_key]
 
-	if(!targetting_datum.can_attack(basic_mob, target))
+	if(controller.is_melee_target_ignored(target) || !targetting_datum.can_attack(basic_mob, target)) // TA EDIT
 		finish_action(controller, FALSE, target_key)
 		return
 
@@ -41,10 +41,17 @@
 	basic_mob.face_atom(target)
 	basic_mob.a_intent = pick(basic_mob.possible_a_intents) //randomized intent
 
+	// TA EDIT START
 	if(hiding_target) //Slap it!
+		controller.reset_melee_attack_progress()
 		basic_mob.ClickOn(hiding_target, list())
 	else
+		var/next_click_before = basic_mob.next_click
 		basic_mob.ClickOn(target, list())
+		if(basic_mob.next_click != next_click_before && controller.record_melee_attack_progress(target, target_key, hiding_location_key))
+			finish_action(controller, FALSE, target_key, targetting_datum_key, hiding_location_key)
+			return
+	// TA EDIT END
 
 	if(sidesteps_after && prob(33)) //this is so fucking hacky, but going off og code this is exactly how it goes ignoring movetimers
 		if(!target || !isturf(target.loc) || !isturf(basic_mob.loc) || basic_mob.stat == DEAD)

--- a/code/datums/ai/behaviors/hostile/static_melee_attack.dm
+++ b/code/datums/ai/behaviors/hostile/static_melee_attack.dm
@@ -26,7 +26,7 @@
 	var/atom/target = controller.blackboard[target_key]
 	var/datum/targetting_datum/targetting_datum = controller.blackboard[targetting_datum_key]
 
-	if(!targetting_datum.can_attack(basic_mob, target))
+	if(controller.is_melee_target_ignored(target) || !targetting_datum.can_attack(basic_mob, target)) // TA EDIT
 		finish_action(controller, FALSE, target_key)
 		return
 
@@ -37,10 +37,17 @@
 	basic_mob.face_atom()
 	basic_mob.a_intent = pick(basic_mob.possible_a_intents)
 	
+	// TA EDIT START
 	if(hiding_target)
+		controller.reset_melee_attack_progress()
 		basic_mob.ClickOn(hiding_target, list())
 	else
+		var/next_click_before = basic_mob.next_click
 		basic_mob.ClickOn(target, list())
+		if(basic_mob.next_click != next_click_before && controller.record_melee_attack_progress(target, target_key, hiding_location_key))
+			finish_action(controller, FALSE, target_key, targetting_datum_key, hiding_location_key)
+			return
+	// TA EDIT END
 
 /datum/ai_behavior/static_melee_attack/finish_action(datum/ai_controller/controller, succeeded, target_key, targetting_datum_key, hiding_location_key)
 	. = ..()

--- a/code/datums/ai/targetting_datum/simple_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simple_targetting_datum.dm
@@ -22,6 +22,11 @@
 	if(isturf(the_target) || !the_target) // bail out on invalids
 		return FALSE
 
+	// TA EDIT START
+	if(living_mob && living_mob.ai_controller && living_mob.ai_controller.is_melee_target_ignored(the_target))
+		return FALSE
+	// TA EDIT END
+
 	var/mob/living/simple_animal/simple_mob = living_mob
 	if(istype(simple_mob) && simple_mob.binded)
 		return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -51,6 +51,16 @@
 	var/lose_patience_timer_id //id for a timer to call LoseTarget(), used to stop mobs fixating on a target they can't reach
 	var/lose_patience_timeout = 300 //30 seconds by default, so there's no major changes to AI behaviour, beyond actually bailing if stuck forever
 
+	// TA EDIT START
+	var/datum/weakref/melee_progress_target
+	var/melee_progress_health
+	var/melee_progress_stat
+	var/melee_progress_since
+	var/melee_no_progress_attacks
+	var/datum/weakref/ignored_melee_target
+	var/ignored_melee_target_until
+	// TA EDIT END
+
 	var/del_on_deaggro = 0 //seconds to delete after losing aggro
 	var/last_aggro_loss = null
 
@@ -252,6 +262,11 @@
 	if(isturf(the_target) || !the_target || the_target.type == /atom/movable/lighting_object) // bail out on invalids
 		return FALSE
 
+	// TA EDIT START
+	if(is_melee_target_ignored(the_target))
+		return FALSE
+	// TA EDIT END
+
 	if(binded)
 		return FALSE
 
@@ -317,7 +332,7 @@
 			addtimer(cb, (i - 1)*delay)
 	else
 		AttackingTarget()
-	if(patience)
+	if(patience && target) // TA EDIT
 		GainPatience()
 
 /mob/living/simple_animal/hostile/proc/CheckAndAttack()
@@ -408,8 +423,70 @@
 	SEND_SIGNAL(src, COMSIG_HOSTILE_ATTACKINGTARGET, target)
 	in_melee = TRUE
 
-	if(!QDELETED(target))
-		return target.attack_animal(src)
+	// TA EDIT START
+	var/atom/attacked_target = target
+	var/result
+	if(!QDELETED(attacked_target))
+		result = attacked_target.attack_animal(src)
+	if(!QDELETED(src) && attacked_target == target)
+		record_melee_attack_progress(attacked_target)
+	return result
+
+/mob/living/simple_animal/hostile/proc/reset_melee_attack_progress()
+	melee_progress_target = null
+	melee_progress_health = null
+	melee_progress_stat = null
+	melee_progress_since = 0
+	melee_no_progress_attacks = 0
+
+/mob/living/simple_animal/hostile/proc/is_melee_target_ignored(atom/checking_target)
+	var/atom/ignored_target = ignored_melee_target?.resolve()
+	if(!ignored_target || world.time >= ignored_melee_target_until)
+		ignored_melee_target = null
+		ignored_melee_target_until = 0
+		return FALSE
+	return ignored_target == checking_target
+
+/mob/living/simple_animal/hostile/proc/record_melee_attack_progress(atom/attacked_target)
+	if(!isliving(attacked_target))
+		reset_melee_attack_progress()
+		return FALSE
+
+	var/mob/living/living_target = attacked_target
+	if(QDELETED(living_target) || living_target.stat == DEAD)
+		reset_melee_attack_progress()
+		return FALSE
+
+	var/mob/living/tracked_target = melee_progress_target?.resolve()
+	if(tracked_target != living_target)
+		reset_melee_attack_progress()
+		melee_progress_target = WEAKREF(living_target)
+		melee_progress_health = living_target.health
+		melee_progress_stat = living_target.stat
+		melee_progress_since = world.time
+		melee_no_progress_attacks = 1
+		return FALSE
+
+	if(living_target.stat != melee_progress_stat || living_target.health < melee_progress_health)
+		melee_progress_health = living_target.health
+		melee_progress_stat = living_target.stat
+		melee_progress_since = world.time
+		melee_no_progress_attacks = 0
+		return FALSE
+
+	if(living_target.health > melee_progress_health)
+		melee_progress_health = living_target.health
+
+	melee_no_progress_attacks++
+	if(melee_no_progress_attacks < AI_MELEE_NO_PROGRESS_LIMIT || world.time < melee_progress_since + AI_MELEE_NO_PROGRESS_TIME)
+		return FALSE
+
+	ignored_melee_target = WEAKREF(living_target)
+	ignored_melee_target_until = world.time + AI_MELEE_IGNORE_TIME
+	reset_melee_attack_progress()
+	LoseTarget()
+	return TRUE
+	// TA EDIT END
 
 /mob/living/simple_animal/hostile/proc/Aggro()
 	vision_range = aggro_vision_range
@@ -434,6 +511,7 @@
 	approaching_target = FALSE
 	in_melee = FALSE
 	walk(src, 0)
+	reset_melee_attack_progress() // TA EDIT
 	LoseAggro()
 
 /mob/living/simple_animal/hostile/proc/revalidate_target_on_faction_change()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -453,7 +453,7 @@
 		return FALSE
 
 	var/mob/living/living_target = attacked_target
-	if(QDELETED(living_target) || living_target.stat == DEAD)
+	if(QDELETED(living_target))
 		reset_melee_attack_progress()
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Добавлена защита от бесконечных безрезультатных атак ИИ. ИИшке было вполне себе заебись в углу карте хуярить труп пока не случится тепловая смерть вселенной или раунд не закончится, засирая все это, конечно, бесконечными логами.

## Testing Evidence

Проверил на локалке, запускается, ИИ работает, но в основном ожидаю протестировать на сервере.

## Why It's Good For The Game

Мобы больше не должны часами атаковать неуязвимые цели без какого-либо результата.

## Changelog

:cl:
fix: ИИ больше не должен бесконечно атаковать цели, которым он длительное время не может нанести урон.
/:cl: