### PR TITLE
Бафы для бандитов и вретчей в их лагерях

### DIFF
--- a/modular_twilight_axis/code/datums/status_effects/rogue/debuff.dm
+++ b/modular_twilight_axis/code/datums/status_effects/rogue/debuff.dm
@@ -52,11 +52,11 @@
 /atom/movable/screen/alert/status_effect/debuff/knockout
 	name = "Drowsy"
 */
-/datum/status_effect/debuff/vampiric_slowdown 
+/datum/status_effect/debuff/vampiric_slowdown
 	id = "vampiric_slowdown"
-	duration = 120 
-	alert_type = null 
-	effectedstats = list(STATKEY_SPD = -10) 
+	duration = 120
+	alert_type = null
+	effectedstats = list(STATKEY_SPD = -10)
 
 /datum/status_effect/debuff/vampiric_slowdown/on_apply()
 	. = ..()
@@ -68,26 +68,53 @@
 		to_chat(owner, span_notice("The burden lifts, and I regain my speed."))
 	. = ..()
 
+/datum/status_effect/debuff/territory
+	var/territory_role
+
+/datum/status_effect/debuff/territory/process()
+	. = ..()
+	if(!ishuman(owner))
+		owner.remove_status_effect(type)
+		return
+
+	var/mob/living/carbon/human/H = owner
+	var/area/current_area = get_area(H)
+	if(!istype(current_area, /area/rogue))
+		H.update_territory_effects()
+		return
+
+	var/area/rogue/rogue_area = current_area
+	var/current_role = H.mind?.special_role
+	if(rogue_area.territory_role != territory_role || current_role == "Bandit" || current_role == "Wretch")
+		H.update_territory_effects()
+
+/datum/status_effect/debuff/territory/bandit
+	id = "bandit_territory_intruder"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/territory/bandit
+	effectedstats = list(STATKEY_STR = -3, STATKEY_PER = -3, STATKEY_INT = -3, STATKEY_CON = -3, STATKEY_WIL = -3, STATKEY_SPD = -3, STATKEY_LCK = -3)
+	territory_role = "Bandit"
+	icon_state = "debuff"
+
 /datum/status_effect/stacking/hypothermia
 	id = "hypothermia"
 	status_type = STATUS_EFFECT_REFRESH
-	max_stacks = 18 
+	max_stacks = 18
 	delay_before_decay = 10 SECONDS
 	tick_interval = 1 SECONDS
-	
+
 	var/last_frozen_time = 0
-	var/current_speed_penalty = 0 
+	var/current_speed_penalty = 0
 
 /datum/status_effect/stacking/hypothermia/refresh(mob/living/new_owner, ...)
 	var/list/A = args
 	var/amount = (A.len >= 2) ? A[2] : 1
 	add_stacks(amount)
-	
+
 /datum/status_effect/stacking/hypothermia/add_stacks(stacks_added)
-	if(!owner || owner.stat == DEAD) 
+	if(!owner || owner.stat == DEAD)
 		return FALSE
-	
-	
+
+
 	var/datum/status_effect/freon/freeze/F = owner.has_status_effect(/datum/status_effect/freon/freeze)
 	if(F)
 		F.ice_integrity = min(F.ice_integrity + (stacks_added * 5), 250)
@@ -96,23 +123,23 @@
 
 	if(stacks_added > 0)
 		last_frozen_time = world.time
-	
+
 	stacks = clamp(stacks + stacks_added, 0, max_stacks)
-	
-	
+
+
 	var/new_penalty = -round(stacks * 0.5)
 	if(new_penalty != current_speed_penalty)
-		owner.change_stat(STATKEY_SPD, -current_speed_penalty) 
+		owner.change_stat(STATKEY_SPD, -current_speed_penalty)
 		current_speed_penalty = new_penalty
-		owner.change_stat(STATKEY_SPD, current_speed_penalty) 
-	
+		owner.change_stat(STATKEY_SPD, current_speed_penalty)
+
 
 	if(stacks == 6)
 		owner.balloon_alert(owner, "My limbs are going numb...")
 	else if(stacks == 12)
 		owner.balloon_alert(owner, "The cold is clouding the mind!")
-	
-	
+
+
 	if(stacks >= 18)
 		do_final_freeze()
 		return TRUE
@@ -121,7 +148,7 @@
 	return TRUE
 
 /datum/status_effect/stacking/hypothermia/proc/update_frost_visuals()
-	if(!owner) 
+	if(!owner)
 		return
 	var/r = clamp(255 - (stacks * 11), 50, 255)
 	var/g = clamp(255 - (stacks * 6), 140, 255)
@@ -130,55 +157,55 @@
 	owner.update_atom_colour()
 
 /datum/status_effect/stacking/hypothermia/tick()
-	if(!owner || owner.stat == DEAD) 
+	if(!owner || owner.stat == DEAD)
 		return
-	
-	
+
+
 	if(world.time > last_frozen_time + delay_before_decay)
 		if(stacks > 0)
 			add_stacks(-1)
-			return 
+			return
 
-	if(!owner) 
+	if(!owner)
 		return
 
 	owner.update_move_intent_slowdown()
 
 
-	if(stacks >= 1 && stacks <= 5) 
-		if(prob(10)) 
+	if(stacks >= 1 && stacks <= 5)
+		if(prob(10))
 			owner.emote("shiver")
 
-	else if(stacks >= 6 && stacks <= 11) 
+	else if(stacks >= 6 && stacks <= 11)
 		owner.adjustFireLoss(1.5)
 		if(owner.stamina < owner.max_stamina)
 			owner.stamina_add(10)
-		
-	else if(stacks >= 12) 
+
+	else if(stacks >= 12)
 		owner.adjustFireLoss(3)
 		owner.adjustOxyLoss(3)
-		
+
 		if(owner.stamina < owner.max_stamina)
 			owner.stamina_add(15)
-		
-		
-		if(prob(15)) 
+
+
+		if(prob(15))
 			owner.apply_status_effect(STATUS_EFFECT_SLEEPING, 40)
-			
-		
+
+
 		if(prob(15))
 			owner.visible_message(span_danger("[owner] is staggering from the terrible cold!"))
 			owner.Knockdown(20)
 
 /datum/status_effect/stacking/hypothermia/proc/do_final_freeze()
-	if(!owner) 
+	if(!owner)
 		return
 	owner.apply_status_effect(/datum/status_effect/freon/freeze)
 	qdel(src)
 
 /datum/status_effect/stacking/hypothermia/on_remove()
 	if(owner)
-		
+
 		owner.change_stat(STATKEY_SPD, -current_speed_penalty)
 		owner.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
 		owner.update_move_intent_slowdown()

--- a/modular_twilight_axis/code/datums/status_effects/rogue/roguebaff.dm
+++ b/modular_twilight_axis/code/datums/status_effects/rogue/roguebaff.dm
@@ -37,18 +37,102 @@
 				preserve = TRUE
 		if(!preserve)
 			owner.remove_status_effect(/datum/status_effect/buff/clergybuff)
-	
+
 /mob/living/carbon/human
 	var/priest_timer_check = 0
 	var/matthios_banner_timer_check = 0
 
+/area/rogue
+	var/territory_role
+
+/area/rogue/outdoors/banditcamp
+	territory_role = "Bandit"
+
+/area/rogue/indoors/banditcamp
+	territory_role = "Bandit"
+
+/area/rogue/outdoors/woods/wretch_lair
+	territory_role = "Wretch"
+
+/area/rogue/under/cave/inhumen
+	territory_role = "Wretch"
+
+/mob/living/carbon/human/proc/update_territory_effects()
+	remove_status_effect(/datum/status_effect/buff/territory/bandit)
+	remove_status_effect(/datum/status_effect/buff/territory/wretch)
+	remove_status_effect(/datum/status_effect/debuff/territory/bandit)
+	remove_status_effect(/datum/status_effect/debuff/territory/wretch)
+
+	var/area/current_area = get_area(src)
+	if(!istype(current_area, /area/rogue))
+		return
+
+	var/area/rogue/rogue_area = current_area
+	var/current_role = mind?.special_role
+
+	switch(rogue_area.territory_role)
+		if("Bandit")
+			if(current_role == "Bandit")
+				apply_status_effect(/datum/status_effect/buff/territory/bandit)
+			else if(current_role != "Wretch")
+				apply_status_effect(/datum/status_effect/debuff/territory/bandit)
+		if("Wretch")
+			if(current_role == "Wretch")
+				apply_status_effect(/datum/status_effect/buff/territory/wretch)
+			else if(current_role != "Bandit")
+				apply_status_effect(/datum/status_effect/debuff/territory/wretch)
+
 /area/rogue/Entered(mob/living/carbon/human/guy)
 
 	.=..()
+	if(!istype(guy))
+		return
 	if((src.holy_area == TRUE) && HAS_TRAIT(guy, TRAIT_CLERGY_TA) && !guy.has_status_effect(/datum/status_effect/buff/clergybuff) && !HAS_TRAIT(guy, TRAIT_EXCOMMUNICATED) && !HAS_TRAIT(guy, TRAIT_HERESIARCH))
 		guy.apply_status_effect(/datum/status_effect/buff/clergybuff)
+	guy.update_territory_effects()
 
-/datum/status_effect/buff/mist_form 
+/datum/status_effect/buff/territory
+	var/territory_role
+
+/datum/status_effect/buff/territory/process()
+	. = ..()
+	if(!ishuman(owner))
+		owner.remove_status_effect(type)
+		return
+
+	var/mob/living/carbon/human/H = owner
+	var/area/current_area = get_area(H)
+	if(!istype(current_area, /area/rogue))
+		H.update_territory_effects()
+		return
+
+	var/area/rogue/rogue_area = current_area
+	if(rogue_area.territory_role != territory_role || H.mind?.special_role != territory_role)
+		H.update_territory_effects()
+
+/datum/status_effect/buff/territory/bandit
+	id = "bandit_territory"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/territory/bandit
+	effectedstats = list(STATKEY_STR = 5, STATKEY_PER = 5, STATKEY_INT = 5, STATKEY_CON = 5, STATKEY_WIL = 5, STATKEY_SPD = 5, STATKEY_LCK = 5)
+	territory_role = "Bandit"
+
+/atom/movable/screen/alert/status_effect/buff/territory/bandit
+	name = "Bandit Territory"
+	desc = "I know every path and hiding place here. This ground belongs to my band."
+	icon_state = "buff"
+
+/datum/status_effect/buff/territory/wretch
+	id = "wretch_territory"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/territory/wretch
+	effectedstats = list(STATKEY_STR = 5, STATKEY_PER = 5, STATKEY_INT = 5, STATKEY_CON = 5, STATKEY_WIL = 5, STATKEY_SPD = 5, STATKEY_LCK = 5)
+	territory_role = "Wretch"
+
+/atom/movable/screen/alert/status_effect/buff/territory/wretch
+	name = "Wretch Territory"
+	desc = "The lair are familiar to me. I am stronger on this ground."
+	icon_state = "buff"
+
+/datum/status_effect/buff/mist_form
 	id = "mist_form"
 	duration = 6666
 	alert_type = /atom/movable/screen/alert/status_effect/buff/dagger_dash
@@ -56,8 +140,8 @@
 /datum/status_effect/buff/mist_form/on_apply()
 	if(!isliving(owner)) return FALSE
 	var/mob/living/L = owner
-	
-	L.alpha = 100 
+
+	L.alpha = 100
 
 	ADD_TRAIT(L, "ethereal", MAGIC_TRAIT)
 	ADD_TRAIT(L, TRAIT_PACIFISM, MAGIC_TRAIT)
@@ -70,24 +154,24 @@
 	L.status_flags |= GODMODE
 
 
-	L.density = FALSE 
-	
+	L.density = FALSE
+
 
 	L.pass_flags |= LETPASSTHROW
 
 	L.pass_flags |= PASSMOB
-	
+
 	return ..()
 
 /datum/status_effect/buff/mist_form/on_remove()
 	var/mob/living/L = owner
 	if(!L) return
-	
+
 	L.alpha = 255
-	
+
 
 	L.density = TRUE
-	
+
 
 	REMOVE_TRAIT(L, "ethereal", MAGIC_TRAIT)
 	REMOVE_TRAIT(L, TRAIT_PACIFISM, MAGIC_TRAIT)
@@ -99,7 +183,7 @@
 	L.status_flags &= ~GODMODE
 	L.pass_flags &= ~LETPASSTHROW
 	L.pass_flags &= ~PASSMOB
-	
+
 	..()
 
 /atom/movable/screen/alert/status_effect/buff/smartium


### PR DESCRIPTION
## About The Pull Request

Теперь вретчам и бандитам в их лагерях даются бафы к статам, а всем чужим на их территории, наоборот, дебафы.
Сделано это чтобы у антагов было больше шансов отбиться от толпы, которая может придти им в хату. 

Пока что вретчи и бандиты на своей территории получают +5 к каждому стату, как чужие -3 к каждому стату. 

Это может быть изменено, я пока еще не решил окончательно какие бафы и дебафы давать

## Testing Evidence

<img width="245" height="98" alt="image" src="https://github.com/user-attachments/assets/e19de4d7-d932-472d-9065-7c138b7834da" />


## Why It's Good For The Game

Возможно люди реже станут вламываться толпой к вретчам или бандитам по приколу, если они будут там встречать сильное сопротивление

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: добавлены бафы для вретчей и бандитов на их территории
add: добавлены дебафы всем чужим на территории вретчей и бандитов
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
