### PR TITLE
Маскарад теперь не жрет слот хард антага

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -218,7 +218,7 @@ SUBSYSTEM_DEF(gamemode)
 	var/holy_warrior = 0
 	var/half_combatant = 0
 	/// Calculated effective pop after weighing garrison & holy warriors at 3x, acolytes at 2x
-	var/effective_pop = 0 
+	var/effective_pop = 0
 
 	/// Is storyteller secret or not
 	var/secret_storyteller = FALSE
@@ -626,13 +626,17 @@ SUBSYSTEM_DEF(gamemode)
 	for(var/datum/round_event_control/antagonist/solo/ec in event_pools[EVENT_TRACK_CHARACTER_INJECTION])
 		if(!ec.roundstart || ec.occurrences)
 			continue
-		if(ec.storyteller_antag_flags & STORYTELLER_ANTAG_VILLAIN)
+		if((ec.storyteller_antag_flags & STORYTELLER_ANTAG_VILLAIN) && ec.consumes_hard_antag_slot)
 			continue	// hard villains are handled by the main roundstart roll
 		var/spawn_it = FALSE
 		if(admin_control)
 			// Admin sandbox: only the assassin slot the admin explicitly opened.
 			if(istype(ec, /datum/round_event_control/antagonist/solo/assassins) && (admin_slots["Assassin"] || 0) > 0)
 				spawn_it = TRUE
+			else if(!ec.consumes_hard_antag_slot)
+				var/slot_key = ec.storyteller_slot_key || antag_slot_key(ec.antag_datum)
+				if(slot_key && (admin_slots[slot_key] || 0) > 0)
+					spawn_it = TRUE
 		else if(preset.guaranteed_hard && !preset.block_soft)
 			// Guaranteed-villain preset: the villain took the main injection slot, so the allowed soft antags
 			// (assassin / dreamwalker) each get an independent RNG chance to spawn alongside it.
@@ -1437,7 +1441,7 @@ SUBSYSTEM_DEF(gamemode)
 	var/list/opened = list()
 	if(allow_vote)
 		return opened
-	for(var/key in list("Bandit", "Lich", "VL", "Masquerade", "Werewolf"))
+	for(var/key in list("Bandit", "Lich", "VL", "Werewolf"))
 		if((admin_slots[key] || 0) > 0)
 			opened += key
 	return opened
@@ -1451,7 +1455,7 @@ SUBSYSTEM_DEF(gamemode)
 	var/list/admin_hard = opened_hard_antags()
 	if(length(admin_hard))
 		for(var/datum/round_event_control/antagonist/solo/event as anything in valid_events)
-			if(event.occurrences)
+			if(event.occurrences || !event.consumes_hard_antag_slot)
 				continue
 			// Use the event's own slot key (Masquerade) when set, else its antag datum's key.
 			if((event.storyteller_slot_key || antag_slot_key(event.antag_datum)) in admin_hard)
@@ -1460,10 +1464,10 @@ SUBSYSTEM_DEF(gamemode)
 	var/datum/storyteller/preset = active_preset()
 	if(!preset?.guaranteed_hard)
 		return guaranteed_events
-	for(var/datum/round_event_control/event as anything in valid_events)
+	for(var/datum/round_event_control/antagonist/solo/event as anything in valid_events)
 		if(event.occurrences)
 			continue
-		if(event.storyteller_antag_flags & STORYTELLER_ANTAG_VILLAIN)
+		if((event.storyteller_antag_flags & STORYTELLER_ANTAG_VILLAIN) && event.consumes_hard_antag_slot)
 			guaranteed_events[event] = valid_events[event]
 	return guaranteed_events
 
@@ -2327,7 +2331,7 @@ SUBSYSTEM_DEF(gamemode)
 	var/total_influence = get_follower_influence(chosen_storyteller)
 	for(var/influence_factor in initialized_storyteller.influence_factors)
 		total_influence += calculate_specific_influence(chosen_storyteller, influence_factor)
-	
+
 	total_influence += initialized_storyteller.bonus_points
 
 	return total_influence

--- a/code/datums/storytellers/_base.dm
+++ b/code/datums/storytellers/_base.dm
@@ -223,7 +223,8 @@
 			return
 		if(track == EVENT_TRACK_CHARACTER_INJECTION && !SSticker?.HasRoundStarted())
 			var/list/guaranteed_events = mode.storyteller_guaranteed_events(valid_events)
-			var/guaranteed_only = length(mode.opened_hard_antags()) || active_preset()?.guaranteed_hard
+			var/datum/storyteller/preset = active_preset()
+			var/guaranteed_only = length(mode.opened_hard_antags()) || preset?.guaranteed_hard
 			if(guaranteed_only)
 				var/list/filtered_out_events = list()
 				for(var/datum/round_event_control/antagonist/solo/event as anything in valid_events)

--- a/code/datums/storytellers/_base.dm
+++ b/code/datums/storytellers/_base.dm
@@ -3,6 +3,9 @@
 /// Lower follower modifier for special storytellers such as Astrata, who is a default patron.
 #define LOWER_FOLLOWER_MODIFIER (STANDARD_FOLLOWER_MODIFIER - 2)
 
+/datum/round_event_control/antagonist/solo
+	var/consumes_hard_antag_slot = TRUE
+
 /datum/storyteller
 	/// Name of our storyteller.
 	var/name = "Badly coded storyteller"
@@ -220,7 +223,8 @@
 			return
 		if(track == EVENT_TRACK_CHARACTER_INJECTION && !SSticker?.HasRoundStarted())
 			var/list/guaranteed_events = mode.storyteller_guaranteed_events(valid_events)
-			if(length(guaranteed_events))
+			var/guaranteed_only = length(mode.opened_hard_antags()) || active_preset()?.guaranteed_hard
+			if(guaranteed_only)
 				var/list/filtered_out_events = list()
 				for(var/datum/round_event_control/antagonist/solo/event as anything in valid_events)
 					if(event in guaranteed_events)
@@ -228,6 +232,10 @@
 					filtered_out_events[event] = "filtered by guaranteed-only roll"
 				mode.log_roundstart_antag_pool(guaranteed_events, filtered_out_events, guaranteed_only = TRUE)
 				valid_events = guaranteed_events
+				if(!length(valid_events))
+					message_admins("Storyteller failed to find a valid hard antagonist for the guaranteed roundstart roll.")
+					mode.event_track_points[track] *= TRACK_FAIL_POINT_PENALTY_MULTIPLIER
+					return
 		picked_event = pickweight(valid_events)
 		if(!picked_event)
 			if(length(valid_events))

--- a/code/modules/events/antagonist/solo/masquerade.dm
+++ b/code/modules/events/antagonist/solo/masquerade.dm
@@ -12,6 +12,7 @@
 	storyteller_pill_label = "Masquerade"
 	storyteller_rumour_name = "a vampire masquerade"
 	storyteller_slot_key = "Masquerade"
+	consumes_hard_antag_slot = FALSE
 
 	weight = 8
 


### PR DESCRIPTION
## About The Pull Request

Маскарад жрал слот хард антага и потому при хайт интенсити вместо лича, вла, бандитов или оборотней мог дропнуться маскарад, который как по мне не особо является хард антагом. Теперь маскарад может выпасть как экстра-антаг.

## Testing Evidence

Должно работать

## Why It's Good For The Game

Люди голосуя за хай интенсити не получат 3 маскарадных вампиров, которые не делают движа на раунд по сравнению с мажорными антагами другими.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Маскарад теперь не жрет слот мажор антагов
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
