### PR TITLE
Зацикленные звуки больше не слышно на 1 Z уровне

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -56,6 +56,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	var/cursound
 	var/list/thingshearing = list() // this is a list of WEAKREFS to the mobs that can currently hear us
 	var/ignore_walls = TRUE
+	var/list/blocked_z_levels
 	var/timerid
 	/// Has the looping started yet?
 	var/loop_started = FALSE
@@ -186,7 +187,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 			var/mob/mob = parent
 			mob.playsound_local(mob, soundfile, volume, vary, frequency, falloff, repeat = src, channel = channel)
 		return
-	var/list/R = playsound(parent, soundfile, volume, vary, extra_range, falloff, frequency, channel, ignore_walls = ignore_walls, repeat = src)
+	var/list/R = playsound(parent, soundfile, volume, vary, extra_range, falloff, frequency, channel, ignore_walls = ignore_walls, repeat = src, blocked_z_levels = blocked_z_levels)
 	for(var/datum/weakref/listener_ref in thingshearing)
 		var/mob/M = listener_ref.resolve()
 		if(!M?.client)

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -2,6 +2,7 @@
 	mid_length = 2400 // 4 minutes for some reason. better would be each song having a specific length
 	volume = 100
 	extra_range = 5
+	blocked_z_levels = list(1)
 	persistent_loop = TRUE
 	var/stress2give = /datum/stressevent/music
 	sound_group = /datum/sound_group/instruments //reserves sound channels for up to 10 instruments at a time

--- a/code/game/objects/structures/roguetown/musicbox.dm
+++ b/code/game/objects/structures/roguetown/musicbox.dm
@@ -5,6 +5,7 @@
 	volume = 70
 	extra_range = 8
 	falloff = 0
+	blocked_z_levels = list(1)
 	persistent_loop = TRUE
 	var/stress2give = /datum/stressevent/music
 	channel = CHANNEL_JUKEBOX

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -2,7 +2,7 @@
 	var/list/played_loops = list() //uses dlink to link to the sound
 
 
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel, pressure_affected = FALSE, ignore_walls = TRUE, soundping = FALSE, repeat, animal_pref = FALSE, quiet = FALSE, pref_toggle)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel, pressure_affected = FALSE, ignore_walls = TRUE, soundping = FALSE, repeat, animal_pref = FALSE, quiet = FALSE, pref_toggle, list/blocked_z_levels)
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
@@ -49,22 +49,22 @@
 		listeners = get_hearers_in_view(maxdistance, turf_source, RECURSIVE_CONTENTS_CLIENT_MOBS)
 	else
 		listeners = get_hearers_in_range(maxdistance, turf_source, RECURSIVE_CONTENTS_CLIENT_MOBS)
-		if(above_turf)
+		if(above_turf && (!blocked_z_levels || !(above_turf.z in blocked_z_levels)))
 			var/list/above_hearers = get_hearers_in_range(maxdistance, above_turf, RECURSIVE_CONTENTS_CLIENT_MOBS)
 			listeners += above_hearers
 			muffled_listeners += above_hearers
-		if(below_turf)
+		if(below_turf && (!blocked_z_levels || !(below_turf.z in blocked_z_levels)))
 			var/list/below_hearers = get_hearers_in_range(maxdistance, below_turf, RECURSIVE_CONTENTS_CLIENT_MOBS)
 			listeners += below_hearers
 			muffled_listeners += below_hearers
 
 	listeners += SSmobs.dead_players_by_zlevel[source_z]
 	if(ignore_walls)
-		if(above_turf)
+		if(above_turf && (!blocked_z_levels || !(above_turf.z in blocked_z_levels)))
 			var/list/above_dead = SSmobs.dead_players_by_zlevel[above_turf.z]
 			listeners += above_dead
 			muffled_listeners += above_dead
-		if(below_turf)
+		if(below_turf && (!blocked_z_levels || !(below_turf.z in blocked_z_levels)))
 			var/list/below_dead = SSmobs.dead_players_by_zlevel[below_turf.z]
 			listeners += below_dead
 			muffled_listeners += below_dead

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -82,7 +82,7 @@
 
 		if(!turf_check)
 			continue
-		if(blocked_z_levels && turf_check.z in blocked_z_levels)
+		if(blocked_z_levels && (turf_check.z in blocked_z_levels))
 			continue
 
 		if(quiet)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -80,6 +80,11 @@
 			if(dullahan.headless)
 				turf_check = get_turf(dullahan.my_head)
 
+		if(!turf_check)
+			continue
+		if(blocked_z_levels && turf_check.z in blocked_z_levels)
+			continue
+
 		if(quiet)
 			if(turf_check.z != turf_source.z)
 				continue


### PR DESCRIPTION
## About The Pull Request

В лобби можно было слышать звуки с тех же X и Y координат на других Z лвлах, ибо играла думала, что 1 Z лвл это просто этаж ниже. Потому в лобби было слышно чертов бумбокс у инквизиции

## Testing Evidence

Я на локалке проверил, бумбокс у инквы не играл

## Why It's Good For The Game

Инквизиции больше не будет заставлять всех в лобби слушать свой бумбокс

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Звуки с других Z лвлов не будет слышно на первом Z лвле
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
