### PR TITLE
Возможность выжигать гниль через голову

### DIFF
--- a/code/modules/surgery/surgeries_hearth/cure_black_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_black_rot.dm
@@ -9,7 +9,10 @@
 		/datum/surgery_step/cauterize
 	)
 	target_mobtypes = list(/mob/living/carbon/human)
-	possible_locs = list(BODY_ZONE_CHEST)
+	possible_locs = list(
+		BODY_ZONE_HEAD,
+		BODY_ZONE_CHEST,
+	)
 
 /datum/surgery_step/extract_black_rose_residue
 	name = "Excise black rot"

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -6,8 +6,10 @@
 		/datum/surgery_step/cauterize
 	)
 	target_mobtypes = list(/mob/living/carbon/human)
-	possible_locs = list(BODY_ZONE_CHEST)
-
+	possible_locs = list(
+		BODY_ZONE_HEAD,
+		BODY_ZONE_CHEST,
+	)
 /datum/surgery_step/burn_rot
 	name = "burn rot"
 	implements = list(


### PR DESCRIPTION
## About The Pull Request

Этот Пр добавляет возможность выжигать гниль через голову!!

## Testing Evidence

Добавил по строчке. Хули там надо

## Why It's Good For The Game

Из-за неснимаймости некоторых доспехов, заражение гнилью является перманентным выводом из раунда при любых условиях. Хоть спасут тебя, хоть легендарный медик, хоть зизо ритуал тебе не поможет. Имхо глупость. 

## Changelog
Гниль теперь можно выжечь через голову

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
Можно выжечь гниль через голову!!!!!
/:cl:
