### PR TITLE
[Balance] Otavan Volf - Repulse Removal

### DIFF
--- a/modular_twilight_axis/firearms/code/jobs/orthodoxist.dm
+++ b/modular_twilight_axis/firearms/code/jobs/orthodoxist.dm
@@ -75,7 +75,7 @@
 	name = "\proper snapped seizing garrote"
 
 /obj/item/inqarticles/garrote/update_damaged_state()
-	icon_angle = initial(icon_angle)	
+	icon_angle = initial(icon_angle)
 	icon_state = "garrote_snap"
 
 /obj/item/inqarticles/garrote/getonmobprop(tag)
@@ -84,7 +84,7 @@
 		switch(tag)
 			if("gen")
 				return list("shrink" = 0.5,"sx" = -4,"sy" = -6,"nx" = 9,"ny" = -6,"wx" = -6,"wy" = -4,"ex" = 4,"ey" = -6,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 90,"wturn" = 93,"eturn" = -12,"nflip" = 0,"sflip" = 1,"wflip" = 0,"eflip" = 0)
-			if("wielded")	
+			if("wielded")
 				return list("shrink" = 0.5,"sx" = -4,"sy" = -6,"nx" = 9,"ny" = -6,"wx" = -6,"wy" = -4,"ex" = 4,"ey" = -6,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 90,"wturn" = 93,"eturn" = -12,"nflip" = 0,"sflip" = 1,"wflip" = 0,"eflip" = 0)
 			if("onbelt")
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
@@ -155,7 +155,7 @@
 	. = ..()
 	lastcarrier = user
 	wipeslate(lastcarrier)
-	if(active)	
+	if(active)
 		if(lastcarrier.pulling)
 			lastcarrier.stop_pulling()
 		playsound(user, 'sound/items/garroteshut.ogg', 65, TRUE)
@@ -168,7 +168,7 @@
 /obj/item/inqarticles/garrote/dropped(mob/user, silent)
 	. = ..()
 	wipeslate(lastcarrier)
-	if(active)	
+	if(active)
 		if(lastcarrier.pulling)
 			lastcarrier.stop_pulling()
 		playsound(user, 'sound/items/garroteshut.ogg', 65, TRUE)
@@ -207,7 +207,7 @@
 			playsound(loc, pick('sound/items/garrote.ogg', 'sound/items/garrote2.ogg'), 65, TRUE)
 			user.visible_message(span_danger("[target] slips past [user]'s attempt to [src] them!"))
 			return
-		// THROAT TARGET RESTRICTION. HEAVILY REQUESTED.	
+		// THROAT TARGET RESTRICTION. HEAVILY REQUESTED.
 		if(user.zone_selected != "neck")
 			to_chat(user, span_warning("I need to wrap it around their throat."))
 			return
@@ -216,8 +216,8 @@
 			return
 		if(HAS_TRAIT(target, TRAIT_GARROTED))
 			to_chat(user, span_warning("They already have one wrapped around their throat."))
-			return	
-		victim = target	
+			return
+		victim = target
 		playsound(loc, 'sound/items/garrotegrab.ogg', 100, TRUE)
 		ADD_TRAIT(user, TRAIT_NOTIGHTGRABMESSAGE, TRAIT_GENERIC)
 		ADD_TRAIT(user, TRAIT_NOSTRUGGLE, TRAIT_GENERIC)
@@ -229,7 +229,7 @@
 		log_garrote_grab(user, target)
 		user.stamina_add(25)
 		user.changeNext_move(CLICK_CD_RAPID)
-		REMOVE_TRAIT(user, TRAIT_NOSTRUGGLE, TRAIT_GENERIC)	
+		REMOVE_TRAIT(user, TRAIT_NOSTRUGGLE, TRAIT_GENERIC)
 		REMOVE_TRAIT(user, TRAIT_NOTIGHTGRABMESSAGE, TRAIT_GENERIC)
 		var/obj/item/grabbing/I = user.get_inactive_held_item()
 		if(istype(I, /obj/item/grabbing/))
@@ -244,7 +244,7 @@
 			return
 		if(user.zone_selected != "neck")
 			to_chat(user, span_warning("I need to constrict the throat."))
-			return	
+			return
 		user.stamina_add(rand(4, 8))
 		var/mob/living/carbon/C = victim
 		// if(get_location_accessible(C, BODY_ZONE_PRECISE_NECK))
@@ -266,8 +266,8 @@
 		log_garrote_choke(user, C, total_oxy_damage)
 		C.visible_message(span_danger("[user] [pick("garrotes", "asphyxiates")] [C]!"), \
 		span_userdanger("[user] [pick("garrotes", "asphyxiates")] me!"), span_hear("I hear the sickening sound of cordage!"), COMBAT_MESSAGE_RANGE, user)
-		to_chat(user, span_danger("I [pick("garrote", "asphyxiate")] [C]!"))	
-		user.changeNext_move(CLICK_CD_RESIST)	//Stops spam for choking.	
+		to_chat(user, span_danger("I [pick("garrote", "asphyxiate")] [C]!"))
+		user.changeNext_move(CLICK_CD_RESIST)	//Stops spam for choking.
 
 /datum/advclass/blackpowder_legionnaire
 	name = "Blackpowder Legionnaire"
@@ -447,12 +447,10 @@
 	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/shadowstep)
 	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/self/invisibility/runed)
 	H.mind?.RemoveSpell(H.mind.get_spell(/datum/action/cooldown/spell/touch/prestidigitation))
-	var/arcane = list("Fetch", "Repulse", "Leap")
+	var/arcane = list("Fetch", "Leap")
 	var/arcane_choice = input("TAKE YOUR RUNE.", "PSYDON'S RUNE.") as anything in arcane
 	switch(arcane_choice)
 		if("Fetch")
 			H.mind?.AddSpell(new /datum/action/cooldown/spell/projectile/fetch)
-		if("Repulse")
-			H.mind?.AddSpell(new /datum/action/cooldown/spell/repulse)
 		if("Leap")
 			H.mind?.AddSpell(new /datum/action/cooldown/spell/leap)


### PR DESCRIPTION
## About The Pull Request
Удаляет старый репульс унаследованный от ныне понерфленной магии, где его нет.

## Testing Evidence
<img width="447" height="393" alt="image" src="https://github.com/user-attachments/assets/11d5031a-596d-4849-abf5-ba03f1cae734" />

## Why It's Good For The Game
Убирает непрерываемое старое заклинание репульса, дарующее несправедливое преимущество для класса с **огнестрельным** оружием, позволяющим ему слишком безнаказанно уходить от опасных ситуаций.

Даже у Т4 магов нет репульса, который нельзя сбить и который помогал бы выходить из окружения и других подобных ситуаций, которые случаются при агрессивной игре, не должно быть и у класса ортодокса, который в данное время благодаря этому "метовому", каждый раз выбираемому спеллу быть чрезвычайно эффективными. 

У данного класса ортодокса помимо репульса остается Fetch и Leap, который позволяет пригятивать убегающую жертву даже через пропасть, а так же Leap, позволящий прямо во время боя менять Z-уровни. 
Класс итак владеет чрезвычайно мощным заклинанием Shadowstep и Psydon Cloak (Который дает невидимость на 20 секунд и впридачу к этому +5 SPD во время своего действия), что хватает для весьма комфортной игры.

## Changelog
:cl:
del: Удален спелл "Repulse" у подкласса Otavan Volf
/:cl: