### PR TITLE
Реверт пожирания стамины за удержание касты и за отмену каста заклинаний

### DIFF
--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -265,7 +265,7 @@
 		if(!can_cast_spell(TRUE))
 			cancel_casting()
 			return PROCESS_KILL
-		if(is_held_ready())
+/*		if(is_held_ready()) // TA EDIT START
 			if(!fully_charged_at)
 				fully_charged_at = world.time
 			var/held_for = world.time - fully_charged_at
@@ -288,7 +288,7 @@
 				owner.balloon_alert(owner, "I cannot hold the spell any longer!")
 				cancel_casting(voluntary = is_held_ready())
 				return PROCESS_KILL
-			invoke_resource_cost(primary_resource_type, ramped_drain)
+			invoke_resource_cost(primary_resource_type, ramped_drain) */ // TA EDIT END
 		refresh_charge_intent()
 		return
 
@@ -1237,7 +1237,7 @@
 	return charge_required && click_to_activate
 
 /datum/action/cooldown/spell/proc/has_hold_cap()
-	return is_held_ready() && !charge_then_click && hold_max_time > hold_grace_time
+	return FALSE // TA EDIT
 
 /datum/action/cooldown/spell/proc/handle_hold_instability(held_for)
 	if(!has_hold_cap())
@@ -1270,11 +1270,7 @@
 	cancel_casting(voluntary = TRUE, cost_mult_override = SPELL_HOLD_TEAR_COST)
 
 /datum/action/cooldown/spell/proc/is_cancel_penalized()
-	if(!cancel_penalty_mult)
-		return FALSE
-	if(!source_aspect || ispath(source_aspect, /datum/magic_aspect/pseudo))
-		return FALSE
-	return TRUE
+	return FALSE // TA EDIT
 
 /datum/action/cooldown/spell/proc/past_cancel_commitment()
 	if(fully_charged || charged)

--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -265,7 +265,8 @@
 		if(!can_cast_spell(TRUE))
 			cancel_casting()
 			return PROCESS_KILL
-/*		if(is_held_ready()) // TA EDIT START
+		/*
+		if(is_held_ready()) // TA EDIT START
 			if(!fully_charged_at)
 				fully_charged_at = world.time
 			var/held_for = world.time - fully_charged_at
@@ -288,7 +289,8 @@
 				owner.balloon_alert(owner, "I cannot hold the spell any longer!")
 				cancel_casting(voluntary = is_held_ready())
 				return PROCESS_KILL
-			invoke_resource_cost(primary_resource_type, ramped_drain) */ // TA EDIT END
+			invoke_resource_cost(primary_resource_type, ramped_drain)
+		*/ // TA EDIT END
 		refresh_charge_intent()
 		return
 


### PR DESCRIPTION
## About The Pull Request

По предложке - https://discord.com/channels/1133928966915358822/1533362080676315216
Теперь маги вновь не тратят стамину за отмену каста или за удержание заклинаний.
Хоть это и звучит как норм идея, но с нынешним балансом магии ни как не стакается и перебор. Если магию апнут достаточно сильно, то можно будет когда-нибудь и вернуть.

## Testing Evidence

На локалке тестил, не умирал от астмы при зажимании фаербола и его отмены

## Why It's Good For The Game

Маги не будут так сильно унижены, как могли бы

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Реверт пожирания стамины за удержание касты и за отмену каста заклинаний
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
