### PR TITLE
Зибантийские подклассы с происхождением багровых земель

### DIFF
--- a/modular_twilight_axis/lore/code/jobs/merc_origins.dm
+++ b/modular_twilight_axis/lore/code/jobs/merc_origins.dm
@@ -35,16 +35,16 @@
 	origin_limits = list(/datum/virtue/origin/azuria)
 
 /datum/advclass/mercenary/desert_rider_almah
-	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian)
+	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian, /datum/virtue/origin/racial/crimson_lands)
 
 /datum/advclass/mercenary/desert_rider
-	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian)
+	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian, /datum/virtue/origin/racial/crimson_lands)
 
 /datum/advclass/mercenary/desert_rider_sahir
-	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian)
+	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian, /datum/virtue/origin/racial/crimson_lands)
 
 /datum/advclass/mercenary/desert_rider_zeybek
-	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian)
+	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian, /datum/virtue/origin/racial/crimson_lands)
 
 /datum/advclass/mercenary/etrusca_condottiero
 	origin_limits = list(/datum/virtue/origin/etrusca)
@@ -53,7 +53,7 @@
 	origin_limits = list(/datum/virtue/origin/etrusca)
 
 /datum/advclass/mercenary/forlorn
-	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian)
+	origin_limits = list(/datum/virtue/origin/raneshen, /datum/virtue/origin/naledi, /datum/virtue/origin/zybantian, /datum/virtue/origin/racial/crimson_lands)
 
 /datum/advclass/mercenary/freelancer
 	origin_limits = list(/datum/virtue/origin/avar)


### PR DESCRIPTION
## About The Pull Request
Зибантийских наёмников можно выбрать с происхождением багровых земель

## Testing Evidence
<img width="462" height="763" alt="image" src="https://github.com/user-attachments/assets/13032177-2409-4dc2-9f9e-79305575c9a0" />

## Why It's Good For The Game
Попросили

## Changelog
:cl:
add: классы Desert Rider и Forlorn Hope Mercenary получили возможность заходить с происхождением Crimsonlander
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
