### PR TITLE
Фогбистов теперь могут брать не только нобели

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/farm/fogbeast.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/fogbeast.dm
@@ -2,7 +2,7 @@ GLOBAL_LIST_INIT(valid_fogbeast_colors, list("White" = COLOR_WHITE, "Gray" = COL
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fogbeast
 	name = "fogbeast mare"
-	desc = "A distant cousin to the saiga, hailing from the mysterious islands of Kaizoku - rarer, but more strongly valued. Extensively used in the Steppes of Aavnr as pack animals and combat mounts."
+	desc = "A riding beast bred from the crossing of saigas and the few horses that still remain in the known world. Fogbeasts are valued for their strength and endurance, and are widely used as pack animals and combat mounts."
 	icon = 'icons/roguetown/mob/monster/fogbeast.dmi'
 	icon_state = "fogbeast"
 	icon_living = "fogbeast"
@@ -194,7 +194,7 @@ GLOBAL_LIST_INIT(valid_fogbeast_colors, list("White" = COLOR_WHITE, "Gray" = COL
 // FOAL
 /mob/living/simple_animal/hostile/retaliate/rogue/fogbeast/kid
 	name = "fogbeast filly"
-	desc = "A young fogbeast, likely to be running around with its mother. Fogbeasts are a distant cousin to the saiga, hailing from the mysterious islands of Kaizoku - rarer, but more strongly valued. Extensively used in the Steppes of Aavnr as pack animals and combat mounts."
+	desc = "A young fogbeast, likely to be running around with its mother. Fogbeasts are riding beasts bred from the crossing of saigas and the few horses that still remain in the known world. They are valued for their strength and endurance, and are widely used as pack animals and combat mounts."
 	icon = 'icons/roguetown/mob/monster/fogbeast.dmi'
 	icon_state = "foggie"
 	icon_living = "foggie"

--- a/code/modules/virtues/saddleborn.dm
+++ b/code/modules/virtues/saddleborn.dm
@@ -73,9 +73,10 @@ GLOBAL_LIST_INIT(virtue_mount_choices_anthrax, (list(
 	var/list/choices = list()
 
 	var/list/mount_choices = GLOB.virtue_mount_choices
-	if (HAS_TRAIT(user, TRAIT_NOBLE) || user.job == "Man at Arms") //TA EDIT
+/*	if (HAS_TRAIT(user, TRAIT_NOBLE) || user.job == "Man at Arms") //TA EDIT
 		to_chat(user, span_info("As an anointed noble, your steed can also come from pedigree stock."))
-		mount_choices += GLOB.virtue_mount_choices_noble
+		mount_choices += GLOB.virtue_mount_choices_noble */
+	mount_choices += GLOB.virtue_mount_choices_noble
 	if (HAS_TRAIT(user, TRAIT_ANTHRAXI))
 		to_chat(user, span_info("As a Drow, you are skilled in handling giant spiders of the Underdark."))
 		mount_choices += GLOB.virtue_mount_choices_anthrax


### PR DESCRIPTION
## About The Pull Request
Теперь можно брать фогбистов не только с трейтом нобеля

## Testing Evidence
<img width="490" height="296" alt="image" src="https://github.com/user-attachments/assets/88392b98-db69-48a3-bc50-86da742da4b5" />

## Why It's Good For The Game
Сайги УРОДЛИВЫЕ. Я хочу кататься на красивых лошадках, а не на носатых чудищах

## Changelog
:cl:
qol: можно выбрать ездового коня в качестве маунта вне зависимости от наличия трейта нобельства
/:cl: