### PR TITLE
Худ для оборотней

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -19,3 +19,4 @@
 
 // TA
 #define ANTAG_HUD_ZIZOID "antag_hud_zizoid"
+#define ANTAG_HUD_WEREWOLF "antag_hud_werewolf" // TA EDIT

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -9,7 +9,8 @@ GLOBAL_LIST_INIT(huds, alist(
 	ANTAG_HUD_REV = new/datum/atom_hud/antag(),
 	ANTAG_HUD_VAMPIRE = new/datum/atom_hud/antag(),
 	ANTAG_HUD_ZOMBIE = new/datum/atom_hud/antag(),
-	ANTAG_HUD_ZIZOID = new/datum/atom_hud/antag()
+	ANTAG_HUD_ZIZOID = new/datum/atom_hud/antag(),
+	ANTAG_HUD_WEREWOLF = new/datum/atom_hud/antag() // TA EDIT
 	))
 
 /datum/atom_hud

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -117,6 +117,7 @@
 	W.cmode_music_override = cmode_music_override
 	W.cmode_music_override_name = cmode_music_override_name
 	mind.transfer_to(W)
+	Were?.add_antag_hud(ANTAG_HUD_WEREWOLF, "werewolf_hud", W) // TA EDIT
 	skills?.known_skills = list()
 	skills?.skill_experience = list()
 	W.grant_language(/datum/language/beast)
@@ -186,6 +187,8 @@
 	REMOVE_TRAIT(W, TRAIT_NOMOOD, TRAIT_SOURCE_WEREWOLF)
 	REMOVE_TRAIT(W, TRAIT_PACIFISM, TRAIT_SOURCE_WEREWOLF)
 
+	var/datum/antagonist/werewolf/Were = mind.has_antag_datum(/datum/antagonist/werewolf/) // TA EDIT
+	Were?.remove_antag_hud(ANTAG_HUD_WEREWOLF, src) // TA EDIT
 	mind.transfer_to(W)
 
 	var/mob/living/carbon/human/species/werewolf/WA = src


### PR DESCRIPTION
## About The Pull Request

Теперь при обращении над человеком появляется значок луны, чтобы оборотням было легче понимать, кто заражен, кто нет.

## Testing Evidence



## Why It's Good For The Game

Оборотням теперь легче будет понять когда они заразили чела

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Добавлен худ у оборотней
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
