### PR TITLE
Уменьшаем размеры колоды Гвинта(Арлетта) в сумке

### DIFF
--- a/modular_twilight_axis/code/cards/card_table/gwynt/items.dm
+++ b/modular_twilight_axis/code/cards/card_table/gwynt/items.dm
@@ -3,6 +3,8 @@
 	desc = "A prepared deck for a round-based game of Arlette."
 	icon = 'modular_twilight_axis/icons/obj/gwynt_objs.dmi'
 	icon_state = "gwint_deck"
+	grid_width = 32
+	grid_height = 32
 	w_class = WEIGHT_CLASS_SMALL
 	var/list/card_ids = list()
 	var/faction_id = CCG_FACTION_AZURIA


### PR DESCRIPTION
## About The Pull Request

Теперь колода Арлетты(торговая марка) не 2 на 2, а 1 на 1, как обычная колода.
## Testing Evidence

Я ради этого даже локалку запустил, смотрите.
<img width="242" height="295" alt="image" src="https://github.com/user-attachments/assets/c3b7df54-a8b5-4b03-943c-413b76724a57" />


## Why It's Good For The Game

Хочется после призыва колоды с собой её таскать. Представьте моё еблище когда увидел, что она размером с арбалет

## Changelog

:cl:

qol: arlette deck now 1x1 in inventory

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
