### PR TITLE
Новый персонаж больше не тырит инфу со старого+ удаление слота

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3443,12 +3443,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 					var/choice_name = tgui_input_list(user, "CHOOSE A HERO","ROGUETOWN", choices)
 					if(choice_name)
 						var/choice = choices[choice_name]
-						// An empty slot must start fresh so it never inherits data from a previously loaded slot.
-						// This only ever writes to the chosen (new) slot and never touches existing ones.
 						if(!load_character(choice) || empty_slots[choice_name])
-							// Start the new slot completely fresh so it never inherits anything
-							// (race, flavortext, ooc notes, etc.) from a previously loaded slot.
-							// Existing slots on disk are never touched.
 							set_new_race(new /datum/species/human/northern())
 							random_character(null, FALSE, TRUE)
 							save_character()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -612,6 +612,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			dat += "<tr>"
 			dat += "<td style='width:33%;text-align:left'>"
 			dat += "<a style='white-space:nowrap;' href='?_src_=prefs;preference=changeslot;'>Change Character</a>"
+			// TA EDIT
 			dat += " | <a style='white-space:nowrap;' href='?_src_=prefs;preference=resetslot;'>Reset Character</a>"
 			dat += "</td>"
 
@@ -3419,6 +3420,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 				if("changeslot")
 					var/list/choices = list()
+					// TA EDIT
 					var/list/empty_slots = list()
 					if(path)
 						var/savefile/S = new /savefile(path)
@@ -3429,6 +3431,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 								S.cd = "/character[i]"
 								S["real_name"] >> name
 								S["topjob"] >> suffix
+								// TA EDIT START
 								var/is_empty = !name
 								if(!name)
 									name = "Slot[i]"
@@ -3454,6 +3457,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 					if(alert(user, "This will wipe ALL data on the currently selected character slot, leaving it as a fresh, empty character. This cannot be undone. Continue?", "Reset Character Slot", "Yes", "No") == "Yes")
 						reset_current_character()
 						to_chat(user, span_notice("Character slot wiped. It is now a fresh, empty character."))
+						// TA EDIT END
 
 				if("tab")
 					if (href_list["tab"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -612,6 +612,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			dat += "<tr>"
 			dat += "<td style='width:33%;text-align:left'>"
 			dat += "<a style='white-space:nowrap;' href='?_src_=prefs;preference=changeslot;'>Change Character</a>"
+			dat += " | <a style='white-space:nowrap;' href='?_src_=prefs;preference=resetslot;'>Reset Character</a>"
 			dat += "</td>"
 
 			dat += "<td style='width:33%;text-align:center'>"
@@ -3418,6 +3419,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 				if("changeslot")
 					var/list/choices = list()
+					var/list/empty_slots = list()
 					if(path)
 						var/savefile/S = new /savefile(path)
 						if(S)
@@ -3427,17 +3429,31 @@ GLOBAL_LIST_EMPTY(chosen_names)
 								S.cd = "/character[i]"
 								S["real_name"] >> name
 								S["topjob"] >> suffix
+								var/is_empty = !name
 								if(!name)
 									name = "Slot[i]"
 								if(suffix)
 									name += " — [suffix]"
 								choices[name] = i
-					var/choice = tgui_input_list(user, "CHOOSE A HERO","ROGUETOWN", choices)
-					if(choice)
-						choice = choices[choice]
-						if(!load_character(choice))
-							random_character(null, FALSE, FALSE)
+								if(is_empty)
+									empty_slots[name] = TRUE
+					var/choice_name = tgui_input_list(user, "CHOOSE A HERO","ROGUETOWN", choices)
+					if(choice_name)
+						var/choice = choices[choice_name]
+						// An empty slot must start fresh so it never inherits data from a previously loaded slot.
+						// This only ever writes to the chosen (new) slot and never touches existing ones.
+						if(!load_character(choice) || empty_slots[choice_name])
+							// Start the new slot completely fresh so it never inherits anything
+							// (race, flavortext, ooc notes, etc.) from a previously loaded slot.
+							// Existing slots on disk are never touched.
+							set_new_race(new /datum/species/human/northern())
+							random_character(null, FALSE, TRUE)
 							save_character()
+
+				if("resetslot")
+					if(alert(user, "This will wipe ALL data on the currently selected character slot, leaving it as a fresh, empty character. This cannot be undone. Continue?", "Reset Character Slot", "Yes", "No") == "Yes")
+						reset_current_character()
+						to_chat(user, span_notice("Character slot wiped. It is now a fresh, empty character."))
 
 				if("tab")
 					if (href_list["tab"])

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -1,17 +1,14 @@
 
-// Wipes every character field on the currently loaded slot and regenerates it as if it were
-// a brand new, never-used slot. The slot index itself is preserved (it is not deleted), and
-// no other slot on disk is ever touched.
+// TA EDIT START
 /datum/preferences/proc/reset_current_character()
 	if(!path)
 		return
-	// Remove the slot's saved data from disk so no stale keys can linger.
+
 	var/savefile/S = new /savefile(path)
 	if(S)
 		S.cd = "/"
 		S.dir -= "character[loaded_slot]"
 
-	// Reset the in-memory character to a fresh, default state.
 	set_new_race(new /datum/species/human/northern())
 	virtue_origin = new pref_species.origin_default
 	virtue = new /datum/virtue/none
@@ -20,7 +17,6 @@
 	race_bonus = null
 	origin = "Default"
 
-	// Regenerate character flaws like a brand new player would get.
 	charflaws = list()
 	var/list/cf_choices = list()
 	for(var/i = 1 to MAX_VICES)
@@ -49,7 +45,6 @@
 	custom_cmode_name = null
 	custom_cmode_file = null
 
-	// Job / class preferences
 	job_preferences = list()
 	job_subprefs = list()
 	job_characters = list()
@@ -58,16 +53,13 @@
 	all_quirks = list()
 	topjob = null
 
-	// Manor
 	have_manor = TRUE
 	manor_name = ""
 	manor_type = "manor"
 
-	// Custom names
 	for(var/custom_name_id in GLOB.preferences_custom_names)
 		custom_names[custom_name_id] = get_default_name(custom_name_id)
 
-	// Descriptions / flavor
 	flavortext = null
 	flavortext_cached = null
 	nsfwflavortext = null
@@ -89,13 +81,11 @@
 	img_gallery = list()
 	nsfw_img_gallery = list()
 
-	// Headshots
 	headshot_link = null
 	lich_headshot_link = null
 	vampire_headshot_link = null
 	werewolf_headshot_link = null
 
-	// Familiar, loadout and customizers
 	familiar_prefs = new /datum/familiar_prefs(src)
 	selected_loadout_items = list()
 	customizer_entries = list()
@@ -103,7 +93,6 @@
 	descriptor_entries = list()
 	custom_descriptors = list()
 
-	// Misc display defaults
 	pronouns = HE_HIM
 	titles_pref = TITLES_M
 	clothes_pref = CLOTHES_M
@@ -120,6 +109,7 @@
 	random_character(null, FALSE, TRUE)
 	save_character()
 
+	// TA EDIT END
 	//The mob should have a gender you want before running this proc. Will run fine without H
 /datum/preferences/proc/random_character(gender_override, antag_override = FALSE, ft_reset = TRUE)
 	if(!pref_species)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -1,4 +1,125 @@
 
+// Wipes every character field on the currently loaded slot and regenerates it as if it were
+// a brand new, never-used slot. The slot index itself is preserved (it is not deleted), and
+// no other slot on disk is ever touched.
+/datum/preferences/proc/reset_current_character()
+	if(!path)
+		return
+	// Remove the slot's saved data from disk so no stale keys can linger.
+	var/savefile/S = new /savefile(path)
+	if(S)
+		S.cd = "/"
+		S.dir -= "character[loaded_slot]"
+
+	// Reset the in-memory character to a fresh, default state.
+	set_new_race(new /datum/species/human/northern())
+	virtue_origin = new pref_species.origin_default
+	virtue = new /datum/virtue/none
+	virtuetwo = new /datum/virtue/none
+	statpack = new /datum/statpack/wildcard/fated
+	race_bonus = null
+	origin = "Default"
+
+	// Regenerate character flaws like a brand new player would get.
+	charflaws = list()
+	var/list/cf_choices = list()
+	for(var/i = 1 to MAX_VICES)
+		cf_choices.Add(i)
+	var/num_vices = pick(cf_choices)
+	var/list/available = GLOB.character_flaws.Copy()
+	for(var/key in available)
+		if(available[key] == /datum/charflaw/noflaw)
+			available.Remove(key)
+			break
+	for(var/j = 1 to num_vices)
+		if(!available.len)
+			break
+		var/sel = pick(available)
+		var/flaw_type = available[sel]
+		available.Remove(sel)
+		var/datum/charflaw/cf = new flaw_type()
+		charflaws.Add(cf)
+	if(!charflaws.len)
+		var/datum/charflaw/no_flaw = new /datum/charflaw/noflaw()
+		charflaws.Add(no_flaw)
+
+	selected_patron = GLOB.patronlist[default_patron]
+	combat_music = GLOB.cmode_tracks_by_type[default_cmusic_type]
+	custom_cmode_enabled = FALSE
+	custom_cmode_name = null
+	custom_cmode_file = null
+
+	// Job / class preferences
+	job_preferences = list()
+	job_subprefs = list()
+	job_characters = list()
+	job_subclass_preferences = list()
+	job_subclass_strict = list()
+	all_quirks = list()
+	topjob = null
+
+	// Manor
+	have_manor = TRUE
+	manor_name = ""
+	manor_type = "manor"
+
+	// Custom names
+	for(var/custom_name_id in GLOB.preferences_custom_names)
+		custom_names[custom_name_id] = get_default_name(custom_name_id)
+
+	// Descriptions / flavor
+	flavortext = null
+	flavortext_cached = null
+	nsfwflavortext = null
+	nsfwflavortext_cached = null
+	ooc_notes = null
+	ooc_notes_cached = null
+	ooc_extra = null
+	ooc_extra_img = null
+	ooc_extra_img_link = null
+	nsfw_ooc_extra_img = null
+	nsfw_ooc_extra_img_link = null
+	erpprefs = null
+	erpprefs_cached = null
+	rumour = null
+	noble_gossip = null
+	averse_chosen_faction = "Inquisition"
+	song_artist = null
+	song_title = null
+	img_gallery = list()
+	nsfw_img_gallery = list()
+
+	// Headshots
+	headshot_link = null
+	lich_headshot_link = null
+	vampire_headshot_link = null
+	werewolf_headshot_link = null
+
+	// Familiar, loadout and customizers
+	familiar_prefs = new /datum/familiar_prefs(src)
+	selected_loadout_items = list()
+	customizer_entries = list()
+	body_markings = list()
+	descriptor_entries = list()
+	custom_descriptors = list()
+
+	// Misc display defaults
+	pronouns = HE_HIM
+	titles_pref = TITLES_M
+	clothes_pref = CLOTHES_M
+	voice_pack = "Default"
+	voice_type = VOICE_TYPE_MASC
+	voice_color = "a0a0a0"
+	voice_pitch = 1
+	char_accent = "No accent"
+	nickname = "Please Change Me"
+	highlight_color = "#FF0000"
+	dnr_pref = FALSE
+	qsr_pref = FALSE
+
+	random_character(null, FALSE, TRUE)
+	save_character()
+
 	//The mob should have a gender you want before running this proc. Will run fine without H
 /datum/preferences/proc/random_character(gender_override, antag_override = FALSE, ft_reset = TRUE)
 	if(!pref_species)


### PR DESCRIPTION
## About The Pull Request
Теперь при попытке занять новый слот он не будет вытаскивать информацию с предыдущего
Добавлена кнопка Reset Character которая полностью устраняет инфу с выбранного слота делая его пустым как будто ты первый раз в игру зашел


## Testing Evidence

Я тестил на локалке, не нашел ничего странного

## Why It's Good For The Game

Вы когда нибудь создавали по пьяне таврофуту и на следующее утро хотели забыть о ее существовании? Ваше настроение словно маятник сначала кричит что отыграть фурричку служаночку это интересно, а через 10 минут ты вспоминаешь про игроков на нобелях? Твоя кукла попала в плен к Хаззи и Они и теперь позор после того что с ней происходило всплывает перед глазами каждый раз когда ты видишь ее? Ты забываешь стирать инфу со старой куклы, и поэтому твоя новая дроуфушка с энормус грудью имеет флавор дворфа слеера?

НЕ БЕДА!
Мои изменения помогут решить все твои проблемы, теперь информация будет спиливаться автоматически, а любой слот можно будет сбросить до изначального если ты этого захочешь

## Changelog
Изменил preferences.dm и preferences_setup.dm для имплементации ранее указанных фич

:cl:
add: Added a reset character button to.. reset your character. shoking i know
qol: Now you dont need to manually clear new slots from previous texts

/:cl:
