### PR TITLE
BUGFIX: Не отображался черный табард в крафте

### DIFF
--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -630,7 +630,7 @@
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
-/datum/crafting_recipe/roguetown/sewing/psydon
+/datum/crafting_recipe/roguetown/sewing/psydontabard
 	name = "tabard, psydonic"
 	category = "Tabards"
 	result = list(/obj/item/clothing/cloak/tabard/psydontabard/black)


### PR DESCRIPTION
## Changelog
Поменял ОДНУ строчку в коде. Теперь blessed tabard можно скрафтить как и планировалось

:cl:

fix: psydonic tabard now craftable

/:cl:

