### PR TITLE
BUGFIX: Мешок с деньгами ест свои же деньги

### DIFF
--- a/code/modules/clothing/rogueclothes/storage/pouch.dm
+++ b/code/modules/clothing/rogueclothes/storage/pouch.dm
@@ -37,7 +37,7 @@
 	if(!storage_comp)
 		return
 
-	//TA EDIT
+	// TA EDIT
 	if(target_coin in storage_comp.contents())
 		return
 

--- a/code/modules/clothing/rogueclothes/storage/pouch.dm
+++ b/code/modules/clothing/rogueclothes/storage/pouch.dm
@@ -37,6 +37,9 @@
 	if(!storage_comp)
 		return
 
+	if(target_coin in storage_comp.contents())
+		return
+
 	var/original_target_quantity = target_coin.quantity	// Store original quantity for verification
 	var/coins_to_collect = original_target_quantity
 

--- a/code/modules/clothing/rogueclothes/storage/pouch.dm
+++ b/code/modules/clothing/rogueclothes/storage/pouch.dm
@@ -37,6 +37,7 @@
 	if(!storage_comp)
 		return
 
+	//TA EDIT
 	if(target_coin in storage_comp.contents())
 		return
 


### PR DESCRIPTION
## About The Pull Request
"Пофикшен" баг с тем чтобы если ты коллектишь мешком через лкм деньги которые уже есть в этом мешке, они удаляются. Теперь ты просто не можешь трогать мешком его же деньги ахахаха (другие мешки все еще нормально работают, не бойтесь либералы)

## Changelog
Добавил ТРИ!!!(3) строчки кода, не может быть

:cl:
fix: fixed pouches devouring their own money with collecting
/:cl:
