### PR TITLE
Фикс потери заточки с равоксом

### DIFF
--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -598,7 +598,7 @@
 			var/obj/item/rogueweapon/RW = user.get_active_held_item()
 			if(RW)
 				RW.take_damage(RW.sharpness ? (INTEG_PARRY_DECAY) : (INTEG_PARRY_DECAY_NOSHARP), BRUTE, used_weapon.d_type)
-				RW.remove_bintegrity((SHARPNESS_ONHIT_DECAY), src)
+				RW.remove_bintegrity((SHARPNESS_ONHIT_DECAY), user)
 
 			//if(used_weapon)
 			//	used_weapon.take_damage((used_weapon.sharpness ? (INTEG_PARRY_DECAY) : (INTEG_PARRY_DECAY_NOSHARP)), BRUTE, used_weapon.d_type)

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -353,7 +353,7 @@
 
 					if(!has_status_effect(/datum/status_effect/buff/weapon_binded))
 						used_weapon.take_damage(intdam, BRUTE, used_weapon.d_type)
-						used_weapon.remove_bintegrity(sharp_loss, user)
+						used_weapon.remove_bintegrity(sharp_loss, defender)
 			else
 				// Unarmed attacker
 				var/intdam = INTEG_PARRY_DECAY_UNARMED
@@ -366,7 +366,7 @@
 				if(istype(used_weapon, /obj/item/rogueweapon/shield) && attack_intent)
 					intdam *= attack_intent.intent_intdamage_factor
 				used_weapon.take_damage(intdam, BRUTE, used_weapon.d_type)
-				used_weapon.remove_bintegrity(sharp_loss, user)
+				used_weapon.remove_bintegrity(sharp_loss, defender)
 			if(mind)
 				dodgetime = CLAMP(dodgetime - 2, 0, CLICK_CD_DODGE)
 				changeMaxDodge(2)


### PR DESCRIPTION
## About The Pull Request

Сейчас патрон равокса бережет заточку оружия не владельца а противника. Так быть не должно.

## Changelog
Изменены аргументы на обратные в строках определяющие кто получает модификатор. Закомпилилось без ошибок.

:cl:
fix: Теперь равоксист корректно получает бонус к уменьшению урона по заточке.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
