### PR TITLE
фикс отображения расы у шкелетов

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -857,6 +857,31 @@ GLOBAL_LIST_INIT(roguetraits, list(
 		}\
 	} while (0)
 
+#define REMOVE_TRAITS_IN(target, sources) \
+	do { \
+		var/list/_L = target.status_traits; \
+		var/list/_S = sources; \
+		if (sources && !islist(sources)) { \
+			_S = list(sources); \
+		} else { \
+			_S = sources\
+		}; \
+		if (_L) { \
+			for (var/_T in _L) { \
+				if (_L[_T]) { \
+					_L[_T] -= _S; \
+				}; \
+				if (!length(_L[_T])) { \
+					_L -= _T; \
+					SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(_T), _T); \
+					}; \
+				};\
+			if (!length(_L)) { \
+				target.status_traits = null\
+			};\
+		}\
+	} while (0)
+
 #define HAS_TRAIT(target, trait) (target.status_traits ? (target.status_traits[trait] ? TRUE : FALSE) : FALSE)
 #define HAS_TRAIT_FROM(target, trait, source) (target.status_traits ? (target.status_traits[trait] ? (source in target.status_traits[trait]) : FALSE) : FALSE)
 #define HAS_TRAIT_FROM_ONLY(target, trait, source) (HAS_TRAIT(target, trait) && (source in target._status_traits[trait]) && (length(target.status_traits[trait]) == 1))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
@@ -31,22 +31,11 @@
 
 	adv_stat_ceiling = list(STAT_INTELLIGENCE = 8, STAT_SPEED = 9, STAT_CONSTITUTION = 10, STAT_WILLPOWER = 12) //infinite fatigue + decent skills vs vamp
 	extra_context = "This class is unable to be revived and all forms of death will dust you."
+	forbidden_races = list(RACES_DESPISED RACES_OOZE) // ta edit
 
 /datum/outfit/job/roguetown/wretch/ancient_deathknight/pre_equip(mob/living/carbon/human/H)
 	..()
-
-	var/had_godmode = (H.status_flags & GODMODE) // TA EDIT START
-	H.status_flags |= GODMODE
-	if(isdullahan(H))
-		var/obj/item/bodypart/head/old_head = H.get_bodypart(BODY_ZONE_HEAD)
-		if(old_head)
-			var/obj/item/bodypart/head/new_head = new /obj/item/bodypart/head()
-			new_head.replace_limb(H, TRUE)
-			qdel(old_head)
-	H.set_species(/datum/species/human/northern)
-	if(!had_godmode)
-		H.status_flags &= ~GODMODE // TA EDIT END
-
+	REMOVE_TRAITS_IN(H, SPECIES_TRAIT)
 	H.become_skeleton()
 
 	// Skeleton antag datum + patron (matching greater_skeleton setup)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
@@ -29,6 +29,7 @@
 	)
 	adv_stat_ceiling = list(STAT_INTELLIGENCE = 12, STAT_SPEED = 9, STAT_CONSTITUTION = 10, STAT_WILLPOWER = 12) //infinite fatigue + spellblade fuckery vs vamp
 	extra_context = "This class is unable to be revived and all forms of death will dust you."
+	forbidden_races = list(RACES_DESPISED RACES_OOZE) // ta edit
 
 /datum/outfit/job/roguetown/wretch/ancient_spellblade
 	var/subclass_selected
@@ -43,18 +44,7 @@
 
 /datum/outfit/job/roguetown/wretch/ancient_spellblade/pre_equip(mob/living/carbon/human/H)
 	..()
-
-	var/had_godmode = (H.status_flags & GODMODE) // TA EDIT START
-	H.status_flags |= GODMODE
-	if(isdullahan(H))
-		var/obj/item/bodypart/head/old_head = H.get_bodypart(BODY_ZONE_HEAD)
-		if(old_head)
-			var/obj/item/bodypart/head/new_head = new /obj/item/bodypart/head()
-			new_head.replace_limb(H, TRUE)
-			qdel(old_head)
-	H.set_species(/datum/species/human/northern)
-	if(!had_godmode)
-		H.status_flags &= ~GODMODE // TA EDIT END
+	REMOVE_TRAITS_IN(H, SPECIES_TRAIT)
 
 	H.become_skeleton()
 

--- a/modular_twilight_axis/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/skeletons.dm
+++ b/modular_twilight_axis/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/skeletons.dm
@@ -34,19 +34,10 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT
 	)
+	forbidden_races = list(RACES_DESPISED RACES_OOZE)
 
 /datum/outfit/job/roguetown/wretch/hero/proc/skelet(mob/living/carbon/human/H)
-	var/had_godmode = (H.status_flags & GODMODE)
-	H.status_flags |= GODMODE
-	if(isdullahan(H))
-		var/obj/item/bodypart/head/old_head = H.get_bodypart(BODY_ZONE_HEAD)
-		if(old_head)
-			var/obj/item/bodypart/head/new_head = new /obj/item/bodypart/head()
-			new_head.replace_limb(H, TRUE)
-			qdel(old_head)
-	H.set_species(/datum/species/human/northern)
-	if(!had_godmode)
-		H.status_flags &= ~GODMODE
+	REMOVE_TRAITS_IN(H, SPECIES_TRAIT)
 	H.hairstyle = "Bald"
 	H.facial_hairstyle = "Shaved"
 	ADD_TRAIT(H, TRAIT_LIMBATTACHMENT, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request
запрещает мурклингам и ревенантам брать шкелетов, также убирается костыль с сетом расы/чеком на реву

вместо этого убираются лишь расовые трейты (это на случай если опять что то по типу мурклингов добавят)

## Почему это очень хорошо
скелетабакси остаются табакси, а не становятся Humen

## Changelog
:cl:
fix: фикс расы у шкелетов
/:cl: