### PR TITLE
Исправление багов + доработка ритуалов Зизо

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -18,13 +18,13 @@
 	var/s = sound(sound)
 	for(var/mob/M in GLOB.player_list)
 		if (!M.can_hear())
-			return
+			continue // TA EDIT
 		if (receiver && !(istype(M, receiver) || (sender && M == sender)))
-			return
+			continue // TA EDIT
 
 		to_chat(M, announcement)
 		if (!sound)
-			return
+			continue // TA EDIT
 		M.playsound_local(M, s, 100)
 
 /proc/minor_announce(message, title = "", alert)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -185,8 +185,8 @@ GLOBAL_VAR_INIT(date_override_offset, 0)
 		playsound_local(src, 'sound/misc/newday.ogg', 60, FALSE)
 		animate(T, alpha = 255, time = 10, easing = EASE_IN)
 		addtimer(CALLBACK(src, PROC_REF(clear_area_text), T), 35)
-		var/time_change_quotes_random = pick(GLOB.time_change_quotes)
-		to_chat(client, span_notice("<b>[time_change_quotes_random]</b>"))
+		// var/time_change_quotes_random = pick(GLOB.time_change_quotes) // TA EDIT
+		// to_chat(client, span_notice("<b>[time_change_quotes_random]</b>")) // TA EDIT
 		var/time_change_tips_random = pick(GLOB.time_change_tips)
 		to_chat(client, span_notice("<i>[time_change_tips_random]</i>"))
 	else if(GLOB.tod == "day")

--- a/code/datums/components/baothajoyride.dm
+++ b/code/datums/components/baothajoyride.dm
@@ -37,12 +37,14 @@
 /datum/component/baotha_joyride/proc/remove_bond()
 	var/mob/living/L = parent
 	if(L)
+		L.remove_filter("joyride") // TA EDIT
 		L.remove_status_effect(/datum/status_effect/baotha_joyride)
 		UnregisterSignal(L, list(
 			COMSIG_PARENT_QDELETING
 		))
 
 	if(partner)
+		partner.remove_filter("joyride") // TA EDIT
 		partner.remove_status_effect(/datum/status_effect/baotha_joyride)
 		var/datum/component/baotha_joyride/other = partner.GetComponent(/datum/component/baotha_joyride)
 		if(other)

--- a/code/game/objects/items/donator_fluff_items.dm
+++ b/code/game/objects/items/donator_fluff_items.dm
@@ -3699,6 +3699,7 @@ As Excaliber."
 	icon = 'icons/obj/items/donor_weapons.dmi'
 	icon_state = "stalkerino_crossbowalt0"
 	item_state = "stalkerino_crossbowalt"
+	hasloadedsprite = FALSE // TA EDIT
 	smeltresult = /obj/item/ingot/drow
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow/donator_stalkerino
@@ -3708,6 +3709,7 @@ As Excaliber."
 	icon = 'icons/obj/items/donor_weapons.dmi'
 	icon_state = "stalkerino_crossbowalt0"
 	item_state = "stalkerino_crossbowalt"
+	hasloadedsprite = FALSE // TA EDIT
 	smeltresult = /obj/item/ingot/drow
 
 /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/donator_stalkerino

--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -635,7 +635,7 @@
 	base_icon_state = "basic_book"
 	override_find_book = TRUE
 
-/obj/item/book/rogue/playerbook/Initialize(mapload, loc, in_round_player_generated, mob/living/in_round_player_mob, text)
+/obj/item/book/rogue/playerbook/Initialize(mapload, in_round_player_generated, mob/living/in_round_player_mob, text) // TA EDIT
 	. = ..()
 	is_in_round_player_generated = in_round_player_generated
 	if(is_in_round_player_generated)

--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -461,23 +461,17 @@
 	. = ..()
 	AddComponent(/datum/component/deaditeslayer, time = 20 SECONDS) // improvised as hell, so it takes a while. sharpen it first you peasant
 
-/obj/item/grown/log/tree/stake/attack_obj(obj/O, mob/living/user)
-	. = ..()
+/obj/item/grown/log/tree/stake/attack_obj(obj/O, mob/living/user) // TA EDIT START
 	if(isitem(O))
 		var/obj/item/I = O
-		if(istype(I, /obj/item/ingot/iron))
+		if(istype(I, /obj/item/ingot/iron) || (I.anvilrepair && I.smeltresult == /obj/item/ingot/iron))
 			if(!do_after(user, 4 SECONDS, target = I))
 				return
 			to_chat(user, span_warning("The [user] breaks an [I] into small parts with the stake!"))
 			new /obj/item/scrap(get_turf(I))
 			qdel(I)
-		if(I.anvilrepair)
-			if(I.smeltresult == /obj/item/ingot/iron)
-				if(!do_after(user, 4 SECONDS, target = I))
-					return
-				to_chat(user, span_warning("The [user] breaks an [I] into small parts with the stake!"))
-				new /obj/item/scrap(get_turf(I))
-				qdel(I)
+			return
+	. = ..() // TA EDIT END
 
 /////////////
 // Planks //

--- a/code/game/objects/items/rogueitems/skillbooks.dm
+++ b/code/game/objects/items/rogueitems/skillbooks.dm
@@ -226,7 +226,7 @@
 				"Fancy Book 7" = "book7",
 				"Fancy Book 8" = "book8",
 				"Knowledge Tome" = "knowledge",
-				"Swatch Book" = "swatchbook",
+//				"Swatch Book" = "swatchbook", // TA EDIT
 				"Bibble" = "bibble",
 				"Psyble" = "psyble",
 				"Law Tome" = "lawtome",

--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -242,9 +242,7 @@
 			if(istype(W, /obj/item/natural/dirtclod))
 				if(!user.temporarilyRemoveItemFromInventory(W))
 					return
-				on = FALSE
-				set_light(0)
-				update_icon()
+				burn_out() // TA EDIT
 				qdel(W)
 				src.visible_message("<span class='warning'>[user] snuffs the fire.</span>")
 				return

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -371,173 +371,194 @@ GLOBAL_LIST_EMPTY(heretical_players)
 
 	return TRUE
 
-/mob/living/carbon/human/proc/churcheapostasy(mob/living/carbon/human/H in GLOB.player_list)
+/mob/living/carbon/human/proc/church_pick_known_target(prompt, title) // TA EDIT START
+	if(!mind)
+		return
+
+	var/list/target_choices = list()
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(!H.mind || !H.real_name)
+			continue
+		if(!mind.do_i_know(person = H.mind))
+			continue
+
+		var/display_name = H.real_name
+		if(target_choices[display_name])
+			var/duplicate_index = 2
+			while(target_choices["[H.real_name] ([duplicate_index])"])
+				duplicate_index++
+			display_name = "[H.real_name] ([duplicate_index])"
+
+		target_choices[display_name] = H
+
+	if(!length(target_choices))
+		to_chat(src, span_warning("I don't know anyone I can name for this judgement."))
+		return
+
+	var/selected_name = tgui_input_list(src, prompt, title, sort_list(target_choices))
+	if(!selected_name)
+		return
+
+	var/mob/living/carbon/human/target = target_choices[selected_name]
+	if(!target || QDELETED(target))
+		to_chat(src, span_warning("That person is no longer within your reach."))
+		return
+
+	return target // TA EDIT END
+
+/mob/living/carbon/human/proc/churcheapostasy() // TA EDIT START
 	set name = "Apostasy"
 	set category = "RoleUnique.Priest"
 
 	if (stat)
 		return
 
-	var/found = FALSE
-	var/inputty = input(src, "Put an apostasy on someone, removing their ability to use miracles... (apostasy them again to remove it)", "Sinner Name") as text|null
-
-	if (!inputty)
-		return
-
 	if (!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
 		to_chat(src, span_warning("I need to do this from the House of the Ten."))
 		return FALSE
 
-	if(!src.key)
+	if(!src.key || !src.mind)
 		return
 
-	if(!src.mind || !src.mind.do_i_know(name=inputty))
-		to_chat(src, span_warning("I don't know anyone by that name."))
+	var/mob/living/carbon/human/H = church_pick_known_target(
+		"Put an apostasy on someone, removing their ability to use miracles. Select them again to forgive the apostasy.",
+		"Apostasy"
+	)
+	if(!H)
 		return
 
-	if (inputty in GLOB.apostasy_players)
-		GLOB.apostasy_players -= inputty
-		priority_announce("[real_name] has forgiven [inputty]. Their patron hears their prayer once more!", title = "APOSTASY LIFTED", sound = 'sound/misc/bell.ogg')
+	var/target_name = H.real_name
+
+	if (target_name in GLOB.apostasy_players)
+		GLOB.apostasy_players -= target_name
+		priority_announce("[real_name] has forgiven [target_name]. Their patron hears their prayer once more!", title = "APOSTASY LIFTED", sound = 'sound/misc/bell.ogg')
 		message_admins("APOSTASY: [real_name] ([ckey]) has used forgiven apostasy at [H.real_name] ([H.ckey])")
 		log_game("APOSTASY: [real_name] ([ckey]) has used forgiven apostasy at [H.real_name] ([H.ckey])")
 
-		if (H.real_name == inputty)
+		if (H.real_name == target_name)
 			if (istype(H.patron, /datum/patron/divine) && H.devotion)
 				H.remove_status_effect(/datum/status_effect/debuff/apostasy)
 				H.remove_stress(/datum/stressevent/apostasy)
 
 		return TRUE
 
-	if (inputty in GLOB.excommunicated_players)
+	if (target_name in GLOB.excommunicated_players)
 		return //No stacking
 
-	if (H.real_name == inputty)
-		if (!COOLDOWN_FINISHED(src, priest_apostasy))
-			to_chat(src, span_warning("You must wait until you can mark another."))
-			return
+	if (!COOLDOWN_FINISHED(src, priest_apostasy))
+		to_chat(src, span_warning("You must wait [DisplayTimeText(COOLDOWN_TIMELEFT(src, priest_apostasy))] before you can mark another.")) // TA EDIT
+		return
 
-		//Check if we can curse this person.
-		if(!churchecancurse(H))
-			return
+	//Check if we can curse this person.
+	if(!churchecancurse(H, TRUE))
+		return
 
-		found = TRUE
-		GLOB.apostasy_players += inputty
-		COOLDOWN_START(src, priest_apostasy, PRIEST_APOSTASY_COOLDOWN)
+	GLOB.apostasy_players += target_name
+	COOLDOWN_START(src, priest_apostasy, PRIEST_APOSTASY_COOLDOWN)
+	to_chat(src, span_notice("You must wait [DisplayTimeText(PRIEST_APOSTASY_COOLDOWN)] before invoking Apostasy again.")) // TA EDIT
 
-		var/curse_resist = HAS_TRAIT(H, TRAIT_CURSE_RESIST)
+	var/curse_resist = HAS_TRAIT(H, TRAIT_CURSE_RESIST)
 
-		if (istype(H.patron, /datum/patron/divine))
-			H.apply_status_effect(/datum/status_effect/debuff/apostasy, curse_resist)
-			H.add_stress(/datum/stressevent/apostasy)
-			to_chat(H, span_warning("A holy silence falls upon you. Your Patron cannot hear you anymore..."))
-		else
-			to_chat(H, span_warning("A holy silence falls upon you..."))
+	if (istype(H.patron, /datum/patron/divine))
+		H.apply_status_effect(/datum/status_effect/debuff/apostasy, curse_resist)
+		H.add_stress(/datum/stressevent/apostasy)
+		to_chat(H, span_warning("A holy silence falls upon you. Your Patron cannot hear you anymore..."))
+	else
+		to_chat(H, span_warning("A holy silence falls upon you..."))
 
-		priority_announce("[real_name] has placed mark of shame upon [inputty]. Their prayers fall on deaf ears.", title = "APOSTASY", sound = 'sound/misc/excomm.ogg')
-		message_admins("APOSTASY: [real_name] ([ckey]) has used apostasy at [H.real_name] ([H.ckey])")
-		log_game("APOSTASY: [real_name] ([ckey]) has used apostasy at [H.real_name] ([H.ckey])")
-		return TRUE
+	priority_announce("[real_name] has placed mark of shame upon [target_name]. Their prayers fall on deaf ears.", title = "APOSTASY", sound = 'sound/misc/excomm.ogg')
+	message_admins("APOSTASY: [real_name] ([ckey]) has used apostasy at [H.real_name] ([H.ckey])")
+	log_game("APOSTASY: [real_name] ([ckey]) has used apostasy at [H.real_name] ([H.ckey])")
+	return TRUE // TA EDIT END
 
-	if (!found)
-		return FALSE
-
-	return
-
-/mob/living/carbon/human/proc/churchexcommunicate(mob/living/carbon/human/H in GLOB.player_list)
+/mob/living/carbon/human/proc/churchexcommunicate() // TA EDIT START
 	set name = "Excommunicate"
 	set category = "RoleUnique.Priest"
 
 	if (stat)
 		return
 
-	var/found = FALSE
-	var/inputty = input(src, "Excommunicate someone, away from the Ten...	(excommunicate them again to remove it)", "Sinner Name") as text|null
-
-	if (!inputty)
-		return
-
 	if (!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
 		to_chat(src, span_warning("I need to do this from the House of the Ten."))
 		return FALSE
 
-	if(!src.key)
+	if(!src.key || !src.mind)
 		return
 
-	if(!src.mind || !src.mind.do_i_know(name=inputty))
-		to_chat(src, span_warning("I don't know anyone by that name."))
+	var/mob/living/carbon/human/H = church_pick_known_target(
+		"Excommunicate someone from the Church of the Ten. Select them again to reconcile them.",
+		"Excommunicate"
+	)
+	if(!H)
 		return
 
-	if (inputty in GLOB.excommunicated_players)
-		GLOB.excommunicated_players -= inputty
-		priority_announce("[real_name] has reconciled [inputty] with the Church. They are once again part of the flock!", title = "RECONCILIATION", sound = 'sound/misc/bell.ogg')
+	var/target_name = H.real_name
+
+	if (target_name in GLOB.excommunicated_players)
+		GLOB.excommunicated_players -= target_name
+		priority_announce("[real_name] has reconciled [target_name] with the Church. They are once again part of the flock!", title = "RECONCILIATION", sound = 'sound/misc/bell.ogg')
 		message_admins("EXCOMMUNICATION: [real_name] ([ckey]) has reconciled [H.real_name] ([H.ckey])")
 		log_game("EXCOMMUNICATION: [real_name] ([ckey]) has reconciled [H.real_name] ([H.ckey])")
 
-		if (H.real_name == inputty)
+		if (H.real_name == target_name)
 			REMOVE_TRAIT(H, TRAIT_EXCOMMUNICATED, TRAIT_GENERIC)
+			to_chat(H, span_notice("You have been reconciled with the Church of the Ten."))
 
 			if (H.patron)
 				if (istype(H.patron, /datum/patron/divine))
 					H.remove_stress(/datum/stressevent/excommunicated)
 					H.remove_status_effect(/datum/status_effect/debuff/excomm)
 					to_chat(H, span_warning("No longer a rotten husk, you walk again in their light."))
-				else
-					return
 		return
 
-	if (inputty in GLOB.apostasy_players)//This is an abysmal way of doing this but uhhhhhhhhhhhhhhhhhh yeah
+	if (target_name in GLOB.apostasy_players)//This is an abysmal way of doing this but uhhhhhhhhhhhhhhhhhh yeah
 		return //No stacking
 
-	if (H.real_name == inputty)
-		if (!COOLDOWN_FINISHED(src, priest_excommunicate))
-			to_chat(src, span_warning("You must wait until you can excommunicate another."))
-			return // Anybody can still be excommunicated, so no extra checks here since it's purely RP and not mechanical.
-		found = TRUE
-		ADD_TRAIT(H, TRAIT_EXCOMMUNICATED, TRAIT_GENERIC)
-		COOLDOWN_START(src, priest_excommunicate, PRIEST_EXCOMMUNICATION_COOLDOWN)
+	if (!COOLDOWN_FINISHED(src, priest_excommunicate))
+		to_chat(src, span_warning("You must wait until you can excommunicate another."))
+		return // Anybody can still be excommunicated, so no extra checks here since it's purely RP and not mechanical.
 
-		if (H.patron)
-			if (istype(H.patron, /datum/patron/divine))
-				H.add_stress(/datum/stressevent/excommunicated)
-				H.apply_status_effect(/datum/status_effect/debuff/excomm)
-				to_chat(H, span_warning("Your divine light has been severed. Gods turn their backs to you."))
-			else
-				return
+	ADD_TRAIT(H, TRAIT_EXCOMMUNICATED, TRAIT_GENERIC)
+	COOLDOWN_START(src, priest_excommunicate, PRIEST_EXCOMMUNICATION_COOLDOWN)
+	to_chat(H, span_userdanger("You have been EXCOMMUNICATED from the Church of the Ten!"))
 
-		if (!found)
-			return FALSE
+	if (H.patron)
+		if (istype(H.patron, /datum/patron/divine))
+			H.add_stress(/datum/stressevent/excommunicated)
+			H.apply_status_effect(/datum/status_effect/debuff/excomm)
+			to_chat(H, span_warning("Your divine light has been severed. Gods turn their backs to you."))
 
-	GLOB.excommunicated_players += inputty
-	priority_announce("[real_name] has excommunicated [inputty]! SHAME!", title = "EXCOMMUNICATION", sound = 'sound/misc/excomm.ogg')
+	GLOB.excommunicated_players += target_name
+	priority_announce("[real_name] has excommunicated [target_name]! SHAME!", title = "EXCOMMUNICATION", sound = 'sound/misc/excomm.ogg')
 	message_admins("EXCOMMUNICATION: [real_name] ([ckey]) has excommunicated [H.real_name] ([H.ckey])")
 	log_game("EXCOMMUNICATION: [real_name] ([ckey]) has excommunicated [H.real_name] ([H.ckey])")
 
-	return
+	return // TA EDIT END
 
 /* PRIEST CURSE - powerful debuffs to punish ppl outside church otherwise use apostasy
 code\modules\admin\verbs\divinewrath.dm has a variant with all the gods so keep that updated if this gets any changes.*/
-/mob/living/carbon/human/proc/churchpriestcurse(mob/living/carbon/human/H in GLOB.player_list)
+/mob/living/carbon/human/proc/churchpriestcurse() // TA EDIT START
 	set name = "Divine Curse"
 	set category = "RoleUnique.Priest"
 
 	if (stat)
 		return
 
-	var/target_name = input(src, "Who shall receive a curse?", "Target Name") as text|null
-
-	if (!target_name)
-		return
-
 	if (!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
 		to_chat(src, span_warning("I need to do this from the House of the Ten."))
 		return FALSE
 
-	if(!src.key)
+	if(!src.key || !src.mind)
 		return
 
-	if(!src.mind || !src.mind.do_i_know(name=target_name))
-		to_chat(src, span_warning("I don't know anyone by that name."))
+	var/mob/living/carbon/human/H = church_pick_known_target(
+		"Who shall receive divine judgement?",
+		"Divine Curse"
+	)
+	if(!H)
 		return
+
+	var/target_name = H.real_name
 
 	var/list/curse_choices = list(
 		"Curse of Astrata" = /datum/curse/astrata,
@@ -547,47 +568,45 @@ code\modules\admin\verbs\divinewrath.dm has a variant with all the gods so keep 
 		"Curse of Xylix" = /datum/curse/xylix,
 		)
 
-	var/curse_pick = input(src, "Choose a curse to apply or lift.", "Select Curse") as null|anything in curse_choices
+	var/curse_pick = tgui_input_list(src, "Choose a curse to apply or lift.", "Divine Curse", curse_choices)
 	if (!curse_pick)
 		return
 
 	var/curse_type = curse_choices[curse_pick]
 
-	if (H.real_name == target_name)
-		var/datum/curse/temp = new curse_type()
+	var/datum/curse/temp = new curse_type()
 
-		if (H.is_cursed(temp))
-			H.remove_curse(temp)
-			priority_announce("[real_name] has lifted [curse_pick] from [H.real_name]! They are once again part of the flock!", title = "REDEMPTION", sound = 'sound/misc/bell.ogg')
-			message_admins("DIVINE CURSE: [real_name] ([ckey]) has removed [curse_pick] from [H.real_name]) ") //[ADMIN_LOOKUPFLW(user)] Maybe add this here if desirable but dunno.
-			log_game("DIVINE CURSE: [real_name] ([ckey]) has removed [curse_pick] from [H.real_name])")
-		else
-			if (length(H.curses) >= 1)
-				to_chat(src, span_syndradio("[H.real_name] is already afflicted by another curse."))
-				message_admins("DIVINE CURSE: [real_name] ([ckey]) has attempted to strike [H.real_name] ([H.ckey] with [curse_pick])")
-				log_game("DIVINE CURSE: [real_name] ([ckey]) has attempted to strike [H.real_name] ([H.ckey] with [curse_pick])")
-				return
+	if (H.is_cursed(temp))
+		H.remove_curse(temp)
+		priority_announce("[real_name] has lifted [curse_pick] from [H.real_name]! They are once again part of the flock!", title = "REDEMPTION", sound = 'sound/misc/bell.ogg')
+		message_admins("DIVINE CURSE: [real_name] ([ckey]) has removed [curse_pick] from [H.real_name]) ") //[ADMIN_LOOKUPFLW(user)] Maybe add this here if desirable but dunno.
+		log_game("DIVINE CURSE: [real_name] ([ckey]) has removed [curse_pick] from [H.real_name])")
+	else
+		if (length(H.curses) >= 1)
+			to_chat(src, span_syndradio("[H.real_name] is already afflicted by another curse."))
+			message_admins("DIVINE CURSE: [real_name] ([ckey]) has attempted to strike [H.real_name] ([H.ckey] with [curse_pick])")
+			log_game("DIVINE CURSE: [real_name] ([ckey]) has attempted to strike [H.real_name] ([H.ckey] with [curse_pick])")
+			return
 
-			if (!COOLDOWN_FINISHED(src, priest_curse))
-				to_chat(src, span_warning("You must wait before invoking a curse again."))
-				return
+		if (!COOLDOWN_FINISHED(src, priest_curse))
+			to_chat(src, span_warning("You must wait before invoking a curse again."))
+			return
 
-			if (H.mind.has_antag_datum(/datum/antagonist))
-				to_chat(src, span_warning("They are outside your grasp."))
-				return
+		if (H.mind.has_antag_datum(/datum/antagonist))
+			to_chat(src, span_warning("They are outside your grasp."))
+			return
 
-			//Check if we can curse this person.
-			if(!churchecancurse(H))
-				return
+		//Check if we can curse this person.
+		if(!churchecancurse(H))
+			return
 
-			COOLDOWN_START(src, priest_curse, PRIEST_CURSE_COOLDOWN)
-			H.add_curse(curse_type)
+		COOLDOWN_START(src, priest_curse, PRIEST_CURSE_COOLDOWN)
+		H.add_curse(curse_type)
 
-			priority_announce("[real_name] has stricken [H.real_name] with [curse_pick]! SHAME!", title = "JUDGEMENT", sound = 'sound/misc/excomm.ogg')
-			message_admins("DIVINE CURSE: [real_name] ([ckey]) has stricken [H.real_name] ([H.ckey] with [curse_pick])")
-			log_game("DIVINE CURSE: [real_name] ([ckey]) has stricken [H.real_name] ([H.ckey] with [curse_pick])")
-
-		return
+		priority_announce("[real_name] has stricken [H.real_name] with [curse_pick]! SHAME!", title = "JUDGEMENT", sound = 'sound/misc/excomm.ogg')
+		message_admins("DIVINE CURSE: [real_name] ([ckey]) has stricken [H.real_name] ([H.ckey] with [curse_pick])")
+		log_game("DIVINE CURSE: [real_name] ([ckey]) has stricken [H.real_name] ([H.ckey] with [curse_pick])")
+	return // TA EDIT END
 
 #undef PRIEST_ANNOUNCEMENT_COOLDOWN
 #undef PRIEST_SERMON_COOLDOWN

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -558,8 +558,6 @@ code\modules\admin\verbs\divinewrath.dm has a variant with all the gods so keep 
 	if(!H)
 		return
 
-	var/target_name = H.real_name
-
 	var/list/curse_choices = list(
 		"Curse of Astrata" = /datum/curse/astrata,
 		"Curse of Noc" = /datum/curse/noc,

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -60,9 +60,11 @@
 /obj/structure/bookcase/random/archive/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/book/rogue/playerbook))
 		var/obj/item/book/rogue/playerbook/PB = I
-		if(PB.is_in_round_player_generated)
-			to_chat(user, span_notice("[SSlibrarian.playerbook2file(PB.player_book_text, PB.player_book_title, PB.player_book_author, PB.player_book_author_ckey, PB.player_book_icon)]"))
-			PB.is_in_round_player_generated = FALSE
+		if(PB.is_in_round_player_generated) // TA EDIT START
+			var/archive_choice = tgui_alert(user, "Would you like to save this book to the archive for future rounds, or simply place it on the shelf?", "Archive Book", list("Save to archive", "Just shelve"))
+			if(archive_choice == "Save to archive")
+				to_chat(user, span_notice("[SSlibrarian.playerbook2file(PB.player_book_text, PB.player_book_title, PB.player_book_author, PB.player_book_author_ckey, PB.player_book_icon)]"))
+				PB.is_in_round_player_generated = FALSE // TA EDIT END
 
 	. = ..()
 

--- a/code/modules/mob/dead/new_player/new_player_panel.dm
+++ b/code/modules/mob/dead/new_player/new_player_panel.dm
@@ -54,7 +54,7 @@
 		"Wretch",
 		"Court Agent",
 		"Bandit",
-		"Assasin"
+		"Assassin"
 	)
 	var/list/count_only_job = list(
 		"Hag"

--- a/code/modules/mob/dead/new_player/new_player_panel.dm
+++ b/code/modules/mob/dead/new_player/new_player_panel.dm
@@ -53,7 +53,8 @@
 		"Adventurer",
 		"Wretch",
 		"Court Agent",
-		"Bandit"
+		"Bandit",
+		"Assasin"
 	)
 	var/list/count_only_job = list(
 		"Hag"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2715,6 +2715,10 @@ GLOBAL_LIST_INIT(sight_trait_signals, build_sight_trait_signals())
 		stack_trace("no offered_to or offered_item in offer_item()")
 		return
 
+	if(offered_to.surrendering) // TA EDIT START
+		to_chat(src, span_warning("[offered_to] cannot take items while surrendering."))
+		return FALSE // TA EDIT END
+
 	var/time_left = COOLDOWN_TIMELEFT(src, offer_cooldown)
 
 	if(time_left)
@@ -2787,6 +2791,12 @@ GLOBAL_LIST_INIT(sight_trait_signals, build_sight_trait_signals())
 	update_a_intents()
 
 /mob/living/proc/try_accept_offered_item(mob/living/offerer, obj/offered_item, stealthy)
+	if(surrendering) // TA EDIT START
+		to_chat(src, span_warning("I cannot take items while surrendering."))
+		to_chat(offerer, span_warning("[src] cannot take items while surrendering."))
+		offerer.stop_offering_item()
+		return FALSE // TA EDIT END
+
 	if(get_active_held_item())
 		to_chat(src, span_warning("I need a free hand to take it!"))
 		return FALSE

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -369,7 +369,7 @@
 		)
 	craftdiff = 0
 
-/datum/crafting_recipe/roguetown/survival/rucksack
+/datum/crafting_recipe/roguetown/survival/rucksack // TA EDIT START
 	name = "rucksack"
 	result = /obj/item/storage/backpack/rogue/backpack/bagpack
 	reqs = list(
@@ -377,10 +377,7 @@
 		/obj/item/rope = 1,
 		)
 	craftdiff = 0
-
-/datum/crafting_recipe/roguetown/survival/rucksack/crafted
-	reqs = list(/obj/item/storage/roguebag/crafted = 1,
-				/obj/item/rope = 1)
+	subtype_reqs = TRUE // TA EDIT END
 
 /datum/crafting_recipe/roguetown/survival/handmirror
 	name = "hand mirror"

--- a/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/rituals.dm
+++ b/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/rituals.dm
@@ -44,17 +44,17 @@ GLOBAL_LIST_INIT(ritual_counters, list())
 	if(!target_turf || !required_type)
 		return null
 	for(var/atom/movable/found_ingredient in target_turf)
+		if(found_ingredient.type == required_type)
+			return found_ingredient
+	for(var/atom/movable/found_ingredient in target_turf)
 		if(istype(found_ingredient, required_type))
 			return found_ingredient
 	return null
 
-/obj/effect/decal/cleanable/sigil/proc/consume_ritual_ingredients(list/ingredients_to_consume)
-	if(!length(ingredients_to_consume))
+/obj/effect/decal/cleanable/sigil/proc/consume_ritual_ingredient(atom/movable/ingredient)
+	if(!ingredient || QDELETED(ingredient) || ismob(ingredient))
 		return
-	for(var/atom/movable/ingredient as anything in ingredients_to_consume)
-		if(!ingredient || QDELETED(ingredient) || ismob(ingredient))
-			continue
-		qdel(ingredient)
+	qdel(ingredient)
 
 // Счетчик количества ритуалов
 /proc/get_ritual_count(ritual_name)
@@ -163,38 +163,37 @@ GLOBAL_LIST_INIT(ritual_counters, list())
 	var/cardinal_success = FALSE
 	var/center_success = FALSE
 	var/dews = 0
-	var/list/ingredients_to_consume = list()
-	var/atom/movable/found_ingredient
+	var/atom/movable/east_ingredient
+	var/atom/movable/south_ingredient
+	var/atom/movable/west_ingredient
+	var/atom/movable/north_ingredient
+	var/atom/movable/center_ingredient
 
 	if(pickritual.e_req)
-		found_ingredient = find_ritual_ingredient(get_step(src, EAST), pickritual.e_req)
-		if(found_ingredient)
+		east_ingredient = find_ritual_ingredient(get_step(src, EAST), pickritual.e_req)
+		if(east_ingredient)
 			dews++
-			ingredients_to_consume += found_ingredient
 	else
 		dews++
 
 	if(pickritual.s_req)
-		found_ingredient = find_ritual_ingredient(get_step(src, SOUTH), pickritual.s_req)
-		if(found_ingredient)
+		south_ingredient = find_ritual_ingredient(get_step(src, SOUTH), pickritual.s_req)
+		if(south_ingredient)
 			dews++
-			ingredients_to_consume += found_ingredient
 	else
 		dews++
 
 	if(pickritual.w_req)
-		found_ingredient = find_ritual_ingredient(get_step(src, WEST), pickritual.w_req)
-		if(found_ingredient)
+		west_ingredient = find_ritual_ingredient(get_step(src, WEST), pickritual.w_req)
+		if(west_ingredient)
 			dews++
-			ingredients_to_consume += found_ingredient
 	else
 		dews++
 
 	if(pickritual.n_req)
-		found_ingredient = find_ritual_ingredient(get_step(src, NORTH), pickritual.n_req)
-		if(found_ingredient)
+		north_ingredient = find_ritual_ingredient(get_step(src, NORTH), pickritual.n_req)
+		if(north_ingredient)
 			dews++
-			ingredients_to_consume += found_ingredient
 	else
 		dews++
 
@@ -202,10 +201,9 @@ GLOBAL_LIST_INIT(ritual_counters, list())
 		cardinal_success = TRUE
 
 	if(pickritual.center_requirement)
-		found_ingredient = find_ritual_ingredient(get_turf(src), pickritual.center_requirement)
-		if(found_ingredient)
+		center_ingredient = find_ritual_ingredient(get_turf(src), pickritual.center_requirement)
+		if(center_ingredient)
 			center_success = TRUE
-			ingredients_to_consume += found_ingredient
 	else
 		center_success = TRUE
 
@@ -224,7 +222,11 @@ GLOBAL_LIST_INIT(ritual_counters, list())
 		user.electrocute_act(10, src)
 		return
 
-	consume_ritual_ingredients(ingredients_to_consume)
+	consume_ritual_ingredient(east_ingredient)
+	consume_ritual_ingredient(south_ingredient)
+	consume_ritual_ingredient(west_ingredient)
+	consume_ritual_ingredient(north_ingredient)
+	consume_ritual_ingredient(center_ingredient)
 	user.playsound_local(user, 'modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/sounds/tesa.ogg', 25)
 	user.whisper("O'vena tesa...")
 

--- a/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/rituals.dm
+++ b/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/rituals.dm
@@ -86,22 +86,20 @@ GLOBAL_LIST_INIT(ritual_counters, list())
 	if(!user.client)
 		return
 
-	var/list/available_rituals = list()
-	var/list/ritual_categories = list()
+	var/list/categories = list(
+		"Servantry" = /datum/ritual/servantry,
+		"Transmutation" = /datum/ritual/transmutation,
+		"Fleshcrafting" = /datum/ritual/fleshcrafting,
+		"Weaponary" = /datum/ritual/weaponary
+	)
 
-	switch(sigil_type)
-		if("Transmutation")
-			ritual_categories = subtypesof(/datum/ritual/transmutation)
-		if("Fleshcrafting")
-			ritual_categories = subtypesof(/datum/ritual/fleshcrafting)
-		if("Servantry")
-			ritual_categories = subtypesof(/datum/ritual/servantry)
-		if("Weaponary")
-			ritual_categories = subtypesof(/datum/ritual/weaponary)
-
-	if(!length(ritual_categories))
+	var/chosen_category = tgui_input_list(user, "Choose Ritual Category:", "Ritual Categories", categories)
+	if(!chosen_category || !user.Adjacent(src))
 		return
 
+	var/category_type = categories[chosen_category]
+	var/list/ritual_categories = subtypesof(category_type)
+	var/list/available_rituals = list()
 	var/current_cultists = length(SSmapping.retainer.cultists)
 
 	for(var/datum/ritual/ritual_type as anything in ritual_categories)
@@ -117,10 +115,10 @@ GLOBAL_LIST_INIT(ritual_counters, list())
 		available_rituals[ritual_name] = ritual_type
 
 	if(!length(available_rituals))
-		to_chat(user, span_warning("No rituals for this rune."))
+		to_chat(user, span_warning("No available rituals in this category."))
 		return
 
-	var/chosen_ritual_name = tgui_input_list(user, "Choose Ritual:", "Rituals [sigil_type]", available_rituals)
+	var/chosen_ritual_name = tgui_input_list(user, "Choose Ritual:", "Rituals - [chosen_category]", available_rituals)
 	if(!chosen_ritual_name || !user.Adjacent(src))
 		return
 

--- a/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/zizocult.dm
+++ b/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/zizocult.dm
@@ -498,37 +498,56 @@
 /obj/effect/decal/cleanable/sigil/NW
 	icon_state = "NW"
 
+/turf/open/floor/proc/can_generate_sigils(mob/M)
+	var/list/required_turfs = list(src)
+	for(var/direction in GLOB.alldirs)
+		var/turf/open/floor/floor = get_step(src, direction)
+		if(!istype(floor))
+			to_chat(M, span_warning("There is not enough space to draw a sigil here."))
+			return FALSE
+		required_turfs += floor
+
+	for(var/turf/open/floor/floor in required_turfs)
+		for(var/obj/A in floor)
+			if(istype(A, /obj/effect/decal/cleanable/sigil))
+				to_chat(M, span_warning("There is already a sigil here."))
+				return FALSE
+			if(A.density && !(A.flags_1 & ON_BORDER_1))
+				to_chat(M, span_warning("There is not enough space to draw a sigil here."))
+				return FALSE
+
+	return TRUE
+
 /turf/open/floor/proc/generateSigils(mob/M, input)
-	var/turf/T = get_turf(M.loc)
-	for(var/obj/A in T)
-		if(istype(A, /obj/effect/decal/cleanable/sigil))
-			to_chat(M, span_warning("There is already a sigil here."))
-			return
-		if(A.density && !(A.flags_1 & ON_BORDER_1))
-			to_chat(M, span_warning("There is already something here."))
-			return
-	if(do_after(M, 5 SECONDS))
-		M.bloody_hands--
-		M.update_inv_gloves()
-		var/obj/effect/decal/cleanable/sigil/C = new(src)
-		C.sigil_type = input
-		playsound(M, 'sound/items/write.ogg', 100)
-		var/list/sigilsPath = list(
-			/obj/effect/decal/cleanable/sigil/N,
-			/obj/effect/decal/cleanable/sigil/S,
-			/obj/effect/decal/cleanable/sigil/E,
-			/obj/effect/decal/cleanable/sigil/W,
-			/obj/effect/decal/cleanable/sigil/NE,
-			/obj/effect/decal/cleanable/sigil/NW,
-			/obj/effect/decal/cleanable/sigil/SE,
-			/obj/effect/decal/cleanable/sigil/SW
-		)
+	if(!can_generate_sigils(M))
+		return
 
-		for(var/i = 1; i <= GLOB.alldirs.len; i++)
-			var/turf/floor = get_step(src, GLOB.alldirs[i])
-			var/sigil = sigilsPath[i]
+	if(!do_after(M, 5 SECONDS))
+		return
 
-			new sigil(floor)
+	if(!can_generate_sigils(M))
+		return
+
+	M.bloody_hands--
+	M.update_inv_gloves()
+	var/obj/effect/decal/cleanable/sigil/C = new(src)
+	C.sigil_type = input
+	playsound(M, 'sound/items/write.ogg', 100)
+	var/list/sigilsPath = list(
+		/obj/effect/decal/cleanable/sigil/N,
+		/obj/effect/decal/cleanable/sigil/S,
+		/obj/effect/decal/cleanable/sigil/E,
+		/obj/effect/decal/cleanable/sigil/W,
+		/obj/effect/decal/cleanable/sigil/NE,
+		/obj/effect/decal/cleanable/sigil/NW,
+		/obj/effect/decal/cleanable/sigil/SE,
+		/obj/effect/decal/cleanable/sigil/SW
+	)
+
+	for(var/i = 1; i <= GLOB.alldirs.len; i++)
+		var/turf/floor = get_step(src, GLOB.alldirs[i])
+		var/sigil = sigilsPath[i]
+		new sigil(floor)
 
 /mob/living/carbon/human/proc/draw_sigil()
 	set name = "Draw Sigil"

--- a/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/zizocult.dm
+++ b/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/zizocult.dm
@@ -518,7 +518,7 @@
 
 	return TRUE
 
-/turf/open/floor/proc/generateSigils(mob/M, input)
+/turf/open/floor/proc/generateSigils(mob/M)
 	if(!can_generate_sigils(M))
 		return
 
@@ -531,7 +531,7 @@
 	M.bloody_hands--
 	M.update_inv_gloves()
 	var/obj/effect/decal/cleanable/sigil/C = new(src)
-	C.sigil_type = input
+	C.sigil_type = "Ritual"
 	playsound(M, 'sound/items/write.ogg', 100)
 	var/list/sigilsPath = list(
 		/obj/effect/decal/cleanable/sigil/N,
@@ -558,19 +558,13 @@
 	if(mind && mind.has_antag_datum(/datum/antagonist/skeleton))
 		return
 
-	var/list/runes = list("Servantry", "Transmutation", "Fleshcrafting", "Weaponary")
-
 	if(!bloody_hands)
 		to_chat(src, span_danger("My hands aren't bloody enough."))
 		return
 
-	var/input = input("Sigil Type", "ZIZO") as null|anything in runes
-	if(!input)
-		return
-
 	var/turf/open/floor/T = get_turf(src)
 	if(istype(T))
-		T.generateSigils(src, input)
+		T.generateSigils(src)
 
 /mob/living/carbon/human/proc/release_minion()
 	set name = "Release Lackey"


### PR DESCRIPTION
## About The Pull Request

Исправляю наши баги из баг-репортов, а также баги, связанные с ритуалами Зизо.

- Исправлены глобальные объявления об отлучении от церкви. Excommunicate, Apostasy и Divine Curse переведены на ТГУИ выбор знакомых персонажей с отображением настоящих имён. Исправлена ошибочная проверка знакомых персонажей у епископа. Apostasy теперь корректно проверяет devotion и показывает оставшееся время кулдауна. По баг-репорту - https://discord.com/channels/1133928966915358822/1544432306444308531

- Исправлено создание книг: сохраняются текст, название и автор. При помещении созданной игроком книги в архив можно выбрать, сохранять ли её для будущих раундов. По баг-репорту - https://discord.com/channels/1133928966915358822/1544673483794030672

- Исправлено расходование ингредиентов в ритуалах Зизо. По баг-репорту - https://discord.com/channels/1133928966915358822/1544366539652857896

- Руну Зизо нельзя нарисовать без свободного пространства 3 на 3.

- Все ритуалы Зизо объединены в одну руну, теперь не надо каждый угол обгаживать рунами.

- Ассасина теперь не показывает в лобби. По баг-репорту - https://discord.com/channels/1133928966915358822/1544523031966384209

- Убран второй лишний крафт рюзкака, теперь он один и принимает подтипы предметов. - https://discord.com/channels/1133928966915358822/1544852924222677033

- Теперь нельзя давать вещи тем, кто сдается, чтобы они не пропадали. По баг-репорту - https://discord.com/channels/1133928966915358822/1544399101649621072

- Убрано дублирование фраз, которые пишутся каждый день. По баг-репорту - https://discord.com/channels/1133928966915358822/1544113593749082223

- Убран выбор стиля swatchbook у книг, так как, такого спрайта просто нет. По баг-репорту - https://discord.com/channels/1133928966915358822/1543942656781189151

- Удар колышком по вещам больше те не отбрасывает. 

- Фикс спрайтов у арбалетов дроу. По баг-репортам - https://discord.com/channels/1133928966915358822/1543688840114475013 ;

- Теперь можно тушить фонари грязью, как и было изначально задумано. По баг-репорту - https://discord.com/channels/1133928966915358822/1543079903271059477

- Теперь фильтр у чуда баотистов - joyride корректно убирается. По баг-репорту - https://discord.com/channels/1133928966915358822/1543022007430414356
## Testing Evidence

<img width="400" height="362" alt="image" src="https://github.com/user-attachments/assets/65710c99-14b5-466f-b54e-8255d8c05b83" />


## Why It's Good For The Game

Баги править это круто

## Changelog

:cl:
fix: Исправлены глобальные объявления об отлучении от церкви. Excommunicate, Apostasy и Divine Curse переведены на ТГУИ выбор знакомых персонажей с отображением настоящих имён. Исправлена ошибочная проверка знакомых персонажей у епископа. Apostasy теперь корректно проверяет devotion и показывает оставшееся время кулдауна. По баг-репорту
fix: Исправлено создание книг: сохраняются текст, название и автор. При помещении созданной игроком книги в архив можно выбрать, сохранять ли её для будущих раундов.
fix: Исправлено расходование ингредиентов в ритуалах Зизо.
fix: Руну Зизо теперь нельзя нарисовать без свободного пространства 3 на 3.
fix: Все ритуалы Зизо объединены в одну руну, теперь не надо каждый угол обгаживать рунами.
fix: Ассасина теперь не показывает в лобби. 
fix: Убран второй лишний крафт рюзкака, теперь он один и принимает подтипы предметов.
fix: Теперь нельзя давать вещи тем, кто сдается, чтобы они не пропадали.
fix: Убрано дублирование фраз, которые пишутся каждый день.
fix: Убран выбор стиля swatchbook у книг, так как, такого спрайта просто нет.
fix: Удар колышком по вещам больше те не отбрасывает.
fix: Фикс спрайтов у арбалетов дроу.
fix: Теперь можно тушить фонари грязью, как и было изначально задумано
fix: Теперь фильтр у чуда баотистов - joyride корректно убирается.
/:cl: