### PR TITLE
Lunacy Embracer больше не стоит 40 пикью

### DIFF
--- a/modular_twilight_axis/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/modular_twilight_axis/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -5,12 +5,10 @@
 	Clergy of Azuria assume you are a radical dendorite and rejected you, your connection with Treefather is weaken but you will serve him whatever it takes."
 	allowed_sexes = list(MALE, FEMALE)
 	forbidden_races = list(RACES_CONSTRUCT)
-	min_pq = 40
 	maximum_possible_slots = 1
 	outfit = /datum/outfit/job/roguetown/wretch/lunacyembracer
 	category_tags = list(CTAG_WRETCH)
 	class_select_category = CLASS_CAT_CLERIC
-	extra_context = "Minimum PQ Required: 40"
 	subclass_languages = list(/datum/language/beast)
 
 	traits_applied = list(


### PR DESCRIPTION
## About The Pull Request

Убирает ограничение для подкласса вретча Lunacy Embracer в 40 пикью.

## Testing Evidence

Ну я просто удалил две строчки...

## Why It's Good For The Game

По какой-то причине, Lunacy Embracer стоит 40 пикью, что выглядит довольно странно, когда ПРИМЕРНО такой же подкласс у адвенчура таких ограничений не имеет. 

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Подкласс Вретча Lunacy Embracer больше не стоит 40 пикью.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
