### PR TITLE
Фикс пачки рантаймов

### DIFF
--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -29,6 +29,7 @@ SUBSYSTEM_DEF(discord)
 	name = "Discord"
 	wait = 3000
 	init_order = INIT_ORDER_DISCORD
+	flags = SS_NO_FIRE // TA EDIT
 
 	// var/list/notify_members = list() // People to save to notify file // TA EDIT START
 	// var/list/notify_members_cache = list() // Copy of previous list, so the SS doesnt have to fire if no new members have been added

--- a/code/controllers/subsystem/rogue/economy/banditry_drain.dm
+++ b/code/controllers/subsystem/rogue/economy/banditry_drain.dm
@@ -97,8 +97,8 @@
 		var/datum/manor/manor = H.mind.get_owned_manor()
 		if(!manor)
 			continue
-		var/outpost_workers = manor.get_outpost_workers()
-		if(outpost_workers <= 0)
+		var/list/outpost_workers = manor.get_outpost_workers()
+		if(outpost_workers["workers"] <= 0)
 			continue
 		if(H.client)
 			if(outpost_reduction > 0)

--- a/code/datums/ai/ai_movement/hybrid_movement.dm
+++ b/code/datums/ai/ai_movement/hybrid_movement.dm
@@ -47,6 +47,9 @@
 		var/turf/end_turf = get_turf(controller.current_movement_target)
 		var/advanced = TRUE
 		var/turf/current_turf = get_turf(movable_pawn)
+		if(!end_turf) // TA EDIT START
+			controller.CancelActions()
+			continue // TA EDIT END
 
 		var/mob/cliented_mob = controller.current_movement_target
 		var/cliented = FALSE

--- a/code/datums/ai/subtrees/human_basic_attack.dm
+++ b/code/datums/ai/subtrees/human_basic_attack.dm
@@ -346,7 +346,8 @@
 	if(!special.apply_cost(pawn))
 		return FALSE
 	SEND_SIGNAL(pawn, COMSIG_MOB_TRY_BARK, 100)
-	special.deploy(pawn, held_weapon, target)
+	if(!special.deploy(pawn, held_weapon, target)) // TA EDIT
+		return FALSE // TA EDIT
 	controller.set_blackboard_key(BB_HUMAN_NPC_TECHNIQUE_CD, world.time + 3 SECONDS)
 	// AI penalty: re-stamp the special cooldown longer than the player baseline so NPCs
 	// can't chain specials as tightly as a human player could. Override replaces the

--- a/code/datums/ai/subtrees/retrieve_arrow.dm
+++ b/code/datums/ai/subtrees/retrieve_arrow.dm
@@ -45,7 +45,7 @@
 	if(!arrow || QDELETED(arrow))
 		controller.clear_blackboard_key(arrow_key)
 		return FALSE
-	controller.current_movement_target = arrow
+	set_movement_target(controller, arrow) // TA EDIT
 	return TRUE
 
 /datum/ai_behavior/retrieve_arrow/perform(delta_time, datum/ai_controller/controller, arrow_key)

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -254,7 +254,10 @@
 	if(!has_dna())
 		return
 
-	switch(deconstruct_block(getblock(dna.uni_identity, DNA_GENDER_BLOCK), 3))
+	var/gender_block = getblock(dna.uni_identity, DNA_GENDER_BLOCK) // TA EDIT START
+	if(isnull(hex2num(gender_block, TRUE)))
+		return
+	switch(deconstruct_block(gender_block, 3)) // TA EDIT END
 		if(G_MALE)
 			gender = MALE
 		if(G_FEMALE)

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -147,6 +147,8 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	on_start()
 
 /datum/looping_sound/proc/stop(null_parent)
+	if(stopped) // TA EDIT
+		return // TA EDIT
 	stopped = TRUE
 	if(null_parent)
 		set_parent(null)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1233,7 +1233,12 @@
 
 /atom/movable/proc/get_filter(name)
 	if(filter_data && filter_data[name])
-		return filters[filter_data.Find(name)]
+		var/filter_index = filter_data.Find(name) // TA EDIT START
+		if(!filter_index || filter_index > length(filters))
+			update_filters()
+			filter_index = filter_data.Find(name)
+		if(filter_index && filter_index <= length(filters))
+			return filters[filter_index] // TA EDIT END
 
 /** Update a filter's parameter and animate this change. If the filter doesn't exist we won't do anything.
  * Basically a [datum/proc/modify_filter] call but with animations. Unmodified filter parameters are kept.

--- a/code/game/objects/effects/track.dm
+++ b/code/game/objects/effects/track.dm
@@ -505,7 +505,7 @@
 
 /obj/effect/track/structure/handle_creation(mob/living/track_source)
 	creator = track_source
-	RegisterSignal(track_source, COMSIG_PARENT_QDELETING, PROC_REF(clear_creator_reference))
+	RegisterSignal(track_source, COMSIG_PARENT_QDELETING, PROC_REF(clear_creator_reference), override = TRUE) // TA EDIT
 	creation_time = world.time
 	track_source.get_track_info(src)
 	real_image = image(icon, src, real_icon_state, ABOVE_OPEN_TURF_LAYER, track_source.dir)

--- a/code/game/objects/items/quiver.dm
+++ b/code/game/objects/items/quiver.dm
@@ -939,6 +939,7 @@
 //referencing the mechanized ore bag code for the autopickup part. look in storage.dm
 /obj/item/quiver/mechanized/equipped(mob/living/user, slot)
 	. = ..()
+	UnregisterSignal(user, COMSIG_MOVABLE_MOVED) // TA EDIT
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_user_moved))
 
 /obj/item/quiver/mechanized/dropped(mob/living/user)

--- a/code/modules/admin/verbs/schizohelp.dm
+++ b/code/modules/admin/verbs/schizohelp.dm
@@ -192,9 +192,11 @@ GLOBAL_LIST_EMPTY(voice_names)
 	return name
 
 /client/proc/answer_schizohelp(datum/schizohelp/schizo, ask_again = FALSE)
-	if(QDELETED(schizo) && schizo.locked && !ask_again)
-		to_chat(src, span_warning("This meditation can no longer be answered..."))
+	if(!istype(schizo, /datum/schizohelp) || QDELETED(schizo)) // TA EDIT START
 		return
+	if(schizo.locked && !ask_again)
+		to_chat(src, span_warning("This meditation can no longer be answered..."))
+		return // TA EDIT END
 	var/mob/schizo_mob = schizo.owner?.resolve()
 	if(!schizo_mob)
 		return

--- a/code/modules/jobs/job_types/roguetown/other/goblin.dm
+++ b/code/modules/jobs/job_types/roguetown/other/goblin.dm
@@ -51,7 +51,11 @@
 		eyes = new /obj/item/organ/eyes/night_vision/zombie
 		eyes.Insert(H)
 		H.ambushable = FALSE
-		H.underwear = "Nude"
+		if(H.underwear) // TA EDIT START
+			var/obj/item/bodypart/underwear_chest = H.get_bodypart(BODY_ZONE_CHEST)
+			if(underwear_chest && H.underwear.undies_feature)
+				underwear_chest.remove_bodypart_feature(H.underwear.undies_feature)
+			QDEL_NULL(H.underwear) // TA EDIT END
 		for(var/datum/charflaw/cf in H.charflaws)
 			H.charflaws.Remove(cf)
 			QDEL_NULL(cf)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1290,12 +1290,12 @@
 		seer = TRUE
 
 	if(HAS_TRAIT(src, TRAIT_DUSTRUNNER))
-		var/mob/living/living_examiner = examiner
+		var/mob/living/living_examiner = isliving(examiner) ? examiner : null // TA EDIT
 		if(HAS_TRAIT(examiner, TRAIT_DUSTRUNNER))
 			heretic_text += "Fellow runner. The dust moves."
 		else if(living_examiner?.patron?.type == /datum/patron/inhumen/matthios)
 			heretic_text += "A Guild runner, by the look of them."
-		else if(examiner.job in GLOB.bathhouse_positions)
+		else if(living_examiner?.job in GLOB.bathhouse_positions) // TA EDIT
 			heretic_text += "One of the Guild's runners. I know the signs."
 
 	if(HAS_TRAIT(src, TRAIT_FREEMAN))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -97,6 +97,8 @@
 	if((istype(src.get_inactive_held_item(), /obj/item/rogueweapon/spear/matthios_standard) || istype(src.get_active_held_item(), /obj/item/rogueweapon/spear/matthios_standard)) && !(world.time < matthios_banner_timer_check + 5 SECONDS))
 		matthios_banner_timer_check = world.time
 		for(var/mob/living/carbon/human/H as anything in SSspatial_grid.orthogonal_range_search(src, SPATIAL_GRID_CONTENTS_TYPE_CLIENTS, 7))
+			if(!ishuman(H)) // TA EDIT
+				continue // TA EDIT
 			if(get_dist(src, H) > 7)
 				continue
 			if(istype(H.patron, /datum/patron/inhumen/matthios))

--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -288,7 +288,11 @@ GLOBAL_LIST_INIT(goblin_pyromancer_aggro, list(
 		QDEL_NULL(eyes)
 	eyes = new /obj/item/organ/eyes/night_vision/nightmare
 	eyes.Insert(src)
-	src.underwear = "Nude"
+	if(src.underwear) // TA EDIT START
+		var/obj/item/bodypart/underwear_chest = get_bodypart(BODY_ZONE_CHEST)
+		if(underwear_chest && src.underwear.undies_feature)
+			underwear_chest.remove_bodypart_feature(src.underwear.undies_feature)
+		QDEL_NULL(src.underwear) // TA EDIT END
 	for(var/datum/charflaw/cf in charflaws)
 		charflaws.Remove(cf)
 		QDEL_NULL(cf)

--- a/code/modules/mob/living/carbon/human/npc/hobgoblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/hobgoblin.dm
@@ -164,7 +164,11 @@
 		QDEL_NULL(eyes)
 	eyes = new /obj/item/organ/eyes/night_vision/nightmare
 	eyes.Insert(src)
-	src.underwear = "Nude"
+	if(src.underwear) // TA EDIT START
+		var/obj/item/bodypart/underwear_chest = get_bodypart(BODY_ZONE_CHEST)
+		if(underwear_chest && src.underwear.undies_feature)
+			underwear_chest.remove_bodypart_feature(src.underwear.undies_feature)
+		QDEL_NULL(src.underwear) // TA EDIT END
 	for(var/datum/charflaw/cf in src.charflaws)
 		QDEL_NULL(cf)
 	update_body()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -259,7 +259,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!message)
 		return
 
-	if(D.flags & SIGNLANG)
+	if(D?.flags & SIGNLANG) // TA EDIT
 		send_speech_sign(message, message_range, src, bubble_type, spans, language, message_mode, original_message)
 	else
 		send_speech(message, message_range, src, bubble_type, spans, language, message_mode, original_message)

--- a/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
@@ -123,7 +123,7 @@ GLOBAL_LIST_INIT(animal_to_undead, list(
 
 	playsound(mob, 'sound/combat/fracture/fracturewet (2).ogg', 100, TRUE)
 	animate(mob)
-	var/undead_type = GLOB.animal_to_undead[mob.type]
+	var/undead_type = get_undead_type(mob.type) // TA EDIT
 	new undead_type(mob.loc)
 	mob.visible_message(span_danger("[mob] walks again... As a terrifying deadite!"))
 

--- a/code/modules/spells/spell_cooldown_projectile.dm
+++ b/code/modules/spells/spell_cooldown_projectile.dm
@@ -74,10 +74,13 @@
 
 /// Fire the projectile(s) at the target.
 /datum/action/cooldown/spell/projectile/proc/fire_projectile(atom/target)
+	var/turf/target_turf = get_turf(target) // TA EDIT START
 	for(var/i in 1 to projectiles_per_fire)
 		var/active_type = (arc_mode && projectile_type_arc) ? projectile_type_arc : projectile_type
 		var/obj/projectile/to_fire = new active_type(owner.loc)
-		ready_projectile(to_fire, target, owner, i)
+		ready_projectile(to_fire, QDELETED(target) ? target_turf : target, owner, i)
+		if(QDELETED(to_fire))
+			continue // TA EDIT END
 		to_fire.fire()
 	return TRUE
 

--- a/code/modules/spells/spell_types/wizard/augmentation/guidance.dm
+++ b/code/modules/spells/spell_types/wizard/augmentation/guidance.dm
@@ -10,6 +10,7 @@
 	cooldown_time = 30 SECONDS
 
 	point_cost = 2
+	charge_required = FALSE // TA EDIT
 	charge_time = 0 // Special
 
 	self_cast_cooldown_multiplier = 1.5

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -157,7 +157,7 @@
 			acheck_dflag = "fire"
 	if(!armor)
 		armor = owner.run_armor_check(zone_precise, acheck_dflag, damage = 0)
-	if(ishuman(owner) && bclass != BCLASS_PICK)
+	if(ishuman(owner) && bclass != BCLASS_PICK && acheck_dflag) // TA EDIT
 		var/mob/living/carbon/human/H = owner
 		var/obj/item/clothing/worn_armor = H.get_best_worn_armor(zone_precise, acheck_dflag)
 		if(worn_armor && !worn_armor.obj_broken)

--- a/modular/Mapping/icons/Mapping_aides.dm
+++ b/modular/Mapping/icons/Mapping_aides.dm
@@ -57,7 +57,8 @@
 	visible_message(span_warning("[src] catches fire!"))
 	var/turf/T = get_turf(src)
 	qdel(src)
-	new /obj/effect/hotspot(T)
+	if(T) // TA EDIT
+		new /obj/effect/hotspot(T) // TA EDIT
 
 /obj/structure/spider/stickyweb/solo
 	icon_state = "stickyweb3"

--- a/modular_twilight_axis/code/modules/erp_system/patches/species.dm
+++ b/modular_twilight_axis/code/modules/erp_system/patches/species.dm
@@ -15,3 +15,7 @@
 			P.apply_customizer_organs_to_mob(H)
 
 		SEND_SIGNAL(H, COMSIG_ERP_ANATOMY_CHANGED)
+
+/datum/species/gnoll/on_species_loss(mob/living/carbon/C)
+	. = ..()
+	UnregisterSignal(C, COMSIG_MOB_SAY)

--- a/modular_twilight_axis/code/modules/jobs/job_types/roguetown/other/skeleton.dm
+++ b/modular_twilight_axis/code/modules/jobs/job_types/roguetown/other/skeleton.dm
@@ -46,7 +46,11 @@
     spawned.base_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, /datum/intent/simple/claw)
     spawned.update_a_intents()
     spawned.ambushable = FALSE
-    spawned.underwear = "Nude"
+    if(spawned.underwear)
+        var/obj/item/bodypart/underwear_chest = spawned.get_bodypart(BODY_ZONE_CHEST)
+        if(underwear_chest && spawned.underwear.undies_feature)
+            underwear_chest.remove_bodypart_feature(spawned.underwear.undies_feature)
+        QDEL_NULL(spawned.underwear)
     spawned.update_body()
     spawned.mob_biotypes = MOB_UNDEAD
     spawned.grant_language(/datum/language/undead)
@@ -75,4 +79,8 @@
 
 /datum/outfit/skeleton/pre_equip(mob/living/carbon/human/equipped_human)
 	. = ..()
-	equipped_human.underwear = "Nude"
+	if(equipped_human.underwear)
+		var/obj/item/bodypart/underwear_chest = equipped_human.get_bodypart(BODY_ZONE_CHEST)
+		if(underwear_chest && equipped_human.underwear.undies_feature)
+			underwear_chest.remove_bodypart_feature(equipped_human.underwear.undies_feature)
+		QDEL_NULL(equipped_human.underwear)

--- a/modular_twilight_axis/code/modules/spells/necromancer.dm
+++ b/modular_twilight_axis/code/modules/spells/necromancer.dm
@@ -156,7 +156,11 @@
 	target.patron = master.patron
 	target.faction = list("undead", "[master.real_name]_faction")
 	target.ambushable = FALSE
-	target.underwear = "Nude"
+	if(target.underwear)
+		var/obj/item/bodypart/underwear_chest = target.get_bodypart(BODY_ZONE_CHEST)
+		if(underwear_chest && target.underwear.undies_feature)
+			underwear_chest.remove_bodypart_feature(target.underwear.undies_feature)
+		QDEL_NULL(target.underwear)
 	target.can_do_sex = FALSE
 	target.cmode_music = 'sound/music/combat_cult.ogg'
 


### PR DESCRIPTION
## About The Pull Request

Исправляет следующие рантаймы:

- Tried to qdel possibly invalid value: Nude
- bad del
- movable_moved overridden. Use override = TRUE to suppress this warning
- parent_preqdeleted overridden. Use override = TRUE to suppress this warning
- Subsystem Discord does not fire() but did not set the SS_NO_FIRE flag
- undefined variable /obj/structure/roguemachine/stockpile/var/tat_trade_locked
- undefined variable /obj/effect/track/var/tat_trade_locked
- Cannot read null.flags
- WARNING: Projectile /obj/projectile/magic/gravel_blast fired without either mouse parameters, or a target atom to aim at!
- Cannot read null.x
- Cannot execute null.remove status effect().
- Cannot execute null.Copy().
- Cannot create objects of type null.
- Charging spell Guidance has no charge time
- undefined variable /mob/dead/observer/admin/var/patron
- undefined variable /mob/dead/observer/var/patron
- Malformed hex number
- mob_say overridden. Use override = TRUE to suppress this warning
- undefined variable /datum/callback/var/owner
- parent_qdeleting overridden. Use override = TRUE to suppress this warning

## Testing Evidence

Проверял на локалке

## Why It's Good For The Game

Рантаймы это плохо

## Changelog

:cl:
fix: Исправлено множество рантаймов
/:cl:
