### PR TITLE
Убираю Hack и lunge у оружия

### DIFF
--- a/code/game/objects/items/donator_fluff_items.dm
+++ b/code/game/objects/items/donator_fluff_items.dm
@@ -1219,7 +1219,7 @@
 	icon = 'icons/obj/items/donor_weapons.dmi'
 	dropshrink = null
 	max_blade_int = 230
-	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier, /datum/intent/sword/thrust/rapier/lunge)
+	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier)  // TA EDIT
 	gripped_intents = null
 	special = /datum/special_intent/piercing_lunge
 	parrysound = list(

--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -634,7 +634,6 @@
 		/datum/intent/sword/thrust/long/halfsword/jab,
 		SWORD_BASH,
 		/datum/intent/sword/thrust/long/deep/halfsword,
-		/datum/intent/sword/thrust/long/halfsword,
 	)
 	onmobprop_overrides = list(
 		"altgrip" = list(

--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -50,7 +50,7 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash/battle)
-	gripped_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/chop/heavy, /datum/intent/axe/bash/battle)
+	gripped_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash/battle) // TA EDIT
 	minstr = 9
 	wdefense = 4
 	anvilrepair = /datum/skill/craft/weaponsmithing
@@ -458,7 +458,7 @@
 	desc = "A hefty battle axe, fashioned from pure silver. Even with a one-handed grasp, an efforted swing carries enough momentum to cleave through maille-and-flesh alike."
 	icon_state = "silveraxe"
 	force = 25 //Forgot this is forced to only be one-handed. My bad.
-	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/chop/heavy, /datum/intent/axe/bash/battle)
+	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash/battle)  // TA EDIT
 	gripped_intents = null
 	minstr = 11
 	max_blade_int = 400
@@ -486,7 +486,7 @@
 	icon_state = "psyaxe"
 	force = 25
 	force_wielded = 25
-	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/chop/heavy, /datum/intent/axe/bash/battle)
+	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash/battle)  // TA EDIT
 	minstr = 11
 	wdefense = 6
 	blade_dulling = DULLING_SHAFT_METAL
@@ -581,7 +581,7 @@
 	force = 15
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
+	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/axe/sweep)  // TA EDIT
 	name = "greataxe"
 	desc = "A large axe, requiring both hands to properly swing. It carves, chops, and cleaves from afar."
 	icon_state = "igreataxe"
@@ -641,7 +641,7 @@
 	force = 15
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(/datum/intent/axe/cut/long/bronze, /datum/intent/axe/chop/long, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
+	gripped_intents = list(/datum/intent/axe/cut/long/bronze, /datum/intent/axe/chop/long, /datum/intent/axe/sweep)  // TA EDIT
 	name = "bronze greataxe"
 	desc = "A massive staff with a bronze axhead mantled onto the wood. It splits and carves from afar with lethal force; be it lumber or limbs."
 	icon_state = "bronzegreataxe"

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1570,7 +1570,7 @@
 	inhand_y_dimension = 64
 	dropshrink = 0.75
 	max_blade_int = 230
-	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier, /datum/intent/sword/thrust/rapier/lunge)
+	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier)  // TA EDIT
 	gripped_intents = null
 	special = /datum/special_intent/piercing_lunge
 	parrysound = list(
@@ -1704,7 +1704,7 @@
 	icon_state = "blacksteelrapier"
 	sheathe_icon = "blacksteelrapier"
 	max_blade_int = 400
-	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier, /datum/intent/sword/thrust/rapier/lunge)
+	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier) // TA EDIT
 	wdefense = 9 //Absurdly high defense, but no added integrity; for the discerning duelmaster.
 	var/used = FALSE
 	var/list/selection = list(

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -81,7 +81,7 @@
 	name = "falx"
 	desc = "An unusual type of curved sword that evolved from the farmer's sickle. It has an inwards edge, making it useful for cutting and chopping, great for destroying shields and men alike."
 	force = 22
-	possible_item_intents = list(/datum/intent/sword/cut/falx, /datum/intent/sword/chop/falx, /datum/intent/sword/cut/falx/heavy, /datum/intent/sword/strike)
+	possible_item_intents = list(/datum/intent/sword/cut/falx, /datum/intent/sword/chop/falx, /datum/intent/sword/strike) // TA EDIT
 	icon_state = "falx"
 	max_blade_int = 230 // Tiny downgrade like the sabre
 	gripped_intents = null
@@ -1351,7 +1351,7 @@
 	desc = "A magnificent shortsword of blacksteel. Divorced from the labors that originally warranted its creation, yet no-less-adept at cleaving \
 	whatever might trouble one's morning strolls."
 	force = 27
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/axe/chop, /datum/intent/sword/cut/sabre/heavy)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/axe/chop) // TA EDIT
 	smeltresult = /obj/item/ingot/blacksteel
 	icon_state = "bs_messer"
 	sheathe_icon = "bs_messer"
@@ -1364,7 +1364,7 @@
 	notoriously cementing itself as the preferred weapon of the Potentate's Hussars."
 	icon_state = "sabre"
 	sheathe_icon = "sabre"
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/cut/sabre/heavy, /datum/intent/sword/thrust/sabre, /datum/intent/sword/strike)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust/sabre, /datum/intent/sword/strike)  // TA EDIT
 	gripped_intents = null
 	parrysound = list('sound/combat/parry/bladed/bladedthin (1).ogg', 'sound/combat/parry/bladed/bladedthin (2).ogg', 'sound/combat/parry/bladed/bladedthin (3).ogg')
 	swingsound = BLADEWOOSH_SMALL
@@ -1536,7 +1536,7 @@
 	wdefense = 6	//Loses 1 wdef for that extra 2 force
 	icon_state = "tabi"
 	icon = 'icons/roguetown/weapons/swords64.dmi'
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/chop, /datum/intent/sword/cut/sabre/heavy, /datum/intent/sword/strike)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/chop, /datum/intent/sword/strike)  // TA EDIT
 	bigboy = TRUE
 	pixel_y = -16
 	pixel_x = -16
@@ -2009,7 +2009,7 @@
 	force = 22
 	force_wielded = 27 // Do not want it to become the meat mulcher on 2 hand with this speed
 	possible_item_intents = list(/datum/intent/sword/cut/falx, /datum/intent/sword/strike, /datum/intent/sword/chop/falx)
-	gripped_intents = list(/datum/intent/sword/cut/falx, /datum/intent/sword/chop/falx, /datum/intent/sword/cut/falx/heavy, /datum/intent/sword/cut/zwei/sweep)
+	gripped_intents = list(/datum/intent/sword/cut/falx, /datum/intent/sword/chop/falx, /datum/intent/sword/cut/zwei/sweep)  // TA EDIT
 	icon_state = "rhomphaia"
 	smeltresult = /obj/item/ingot/steel
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -522,7 +522,7 @@
 	icon_state = "germanlong"
 	max_blade_int = 275
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/dagger/sucker_punch, SWORD_STRIKE)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/sword/thrust/long/halfsword/lesser, /datum/intent/sword/chop)
+	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/sword/chop) // TA EDIT
 	wlength = WLENGTH_NORMAL
 
 /obj/item/rogueweapon/sword/long/zizo

--- a/code/game/objects/items/rogueweapons/melee/swords/greatswords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/greatswords.dm
@@ -4,7 +4,7 @@
 	possible_item_intents = list(/datum/intent/sword/chop, /datum/intent/sword/strike) //bash is for nonlethal takedowns, only targets limbs
 	// Design Intent: I have a big fucking sword and I want to cut everything in sight.
 	gripped_intents = list(/datum/intent/sword/cut/zwei, /datum/intent/sword/thrust/zwei, /datum/intent/sword/cut/zwei/cleave, /datum/intent/sword/cut/zwei/sweep)
-	alt_grips = list(/datum/alt_grip/mordhau/greatsword, /datum/alt_grip/halfsword/greatsword)
+	alt_grips = list(/datum/alt_grip/mordhau/greatsword) // TA EDIT
 	name = "greatsword"
 	desc = "Might be able to chop anything in half!"
 	icon_state = "gsw"

--- a/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/thingsforcult.dm
+++ b/modular_twilight_axis/code/modules/roguetown/rogueantagonists/zizo_cult/thingsforcult.dm
@@ -325,7 +325,7 @@ GLOBAL_DATUM_INIT(html_tags, /regex, regex(@"<.*?>", "g"))
 	max_blade_int = 350
 	max_integrity = 300
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop)
-	gripped_intents = list(/datum/intent/axe/cut/cult, /datum/intent/axe/chop/cult, /datum/intent/axe/chop/heavy, /datum/intent/axe/bash/battle)
+	gripped_intents = list(/datum/intent/axe/cut/cult, /datum/intent/axe/chop/cult, /datum/intent/axe/bash/battle)  // TA EDIT
 	smeltresult = /obj/item/ingot/steel/zizo
 
 /datum/intent/axe/chop/cult


### PR DESCRIPTION
## About The Pull Request

Эти интенты весьма странные. Они позволяют пробить любую броню и обходят любое парирование, потому навык пользователя не имеет значение. Топором с хаком может пользоваться, в целом, кто угодно, в теории. 1 на 1 если еще можно как то противостоять человеку с такими интентами, то в битвах толпы это превращается в превращение в фарш за пару пропущенных ударов. Какие-нибудь маги вообще в ахуе, ибо они не могут кастовать, пока их бьют хаком, так как им НАДО любой ценой прерывать хак, иначе их ждет Некра. Я не знаю как балансить эти интенты так, чтобы они были нормальными. Я их вижу или имбой, или бесполезным мусором, если занерфить. Лучше пусть их не будет вообще.

Если топоры потеряют смысл существования, то им можно будет дать что то другое или усилить какой-нибудь уже существующий чоп, а не добавлять расщепление на атомы в виде интента.

## Testing Evidence

Я просто убрал интенты.

## Why It's Good For The Game

Теперь 3 лесника не будут убивать за наносекунду любого антага, которому не посчастливиться попасть к ним.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: убраны хаки и лунжы у оружия
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
