### PR TITLE
Бандиты не мешают в хай интенсити выпасть мажорам

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1056,6 +1056,8 @@ SUBSYSTEM_DEF(gamemode)
 			continue
 		seen += label
 		caps[label] = cap
+	if(preset.allow_dreamwalker) // TA EDIT
+		caps["Dreamwalker"] = 1 // TA EDIT
 	return caps
 
 /// Compact pill row shown under a preset in the vote panel: each antag the preset opens and its max count, at a
@@ -1280,6 +1282,8 @@ SUBSYSTEM_DEF(gamemode)
 		return FALSE
 	if(isnull(player_count))
 		player_count = get_correct_popcount()
+	if(antag_datum == /datum/antagonist/bandit && story_policy_type(TRUE) == /datum/storyteller/gamemode/guaranteed_antag) // TA EDIT
+		return player_count >= 60 // TA EDIT
 	return player_count >= story_antag_min_players(antag_datum)
 
 /// Lazy cache: antag type path -> assoc list of storyteller type -> max cap (or null if none defined).
@@ -1302,6 +1306,11 @@ SUBSYSTEM_DEF(gamemode)
 	if(!ispath(antag_datum, /datum/antagonist))
 		return 0
 	storyteller_type = story_policy_type(roundstart, storyteller_type)
+	if(antag_datum == /datum/antagonist/bandit) // TA EDIT START
+		if(storyteller_type == /datum/storyteller/gamemode/guaranteed_antag)
+			return 5
+		if(storyteller_type == /datum/storyteller/gamemode/guaranteed_antag/low_wretch)
+			return 9 // TA EDIT END
 	var/storyteller_antag_flags = initial(antag_datum:storyteller_antag_flags)
 	if(storyteller_blocks_antag(storyteller_antag_flags, roundstart, storyteller_type) && !(ispath(antag_datum, /datum/antagonist/bandit) && storyteller_type == /datum/storyteller/gamemode/no_antag)) // TA EDIT
 		return 0
@@ -1311,11 +1320,15 @@ SUBSYSTEM_DEF(gamemode)
 		return max(0, maxcaps[storyteller_type])
 	return default_cap
 /datum/controller/subsystem/gamemode/proc/story_antag_slots(slot_count, antag_datum, player_count = null)
-	if(slot_count <= 0)
-		return 0
 	if(isnull(player_count))
 		player_count = get_correct_popcount()
-	if(ispath(antag_datum, /datum/antagonist/bandit)) // TA EDIT START
+	if(antag_datum == /datum/antagonist/bandit && story_policy_type(TRUE) == /datum/storyteller/gamemode/guaranteed_antag) // TA EDIT START
+		var/admin_bandit_slot = get_admin_slot(antag_datum)
+		if(isnull(admin_bandit_slot))
+			return player_count >= 60 ? 5 : 0
+	if(slot_count <= 0)
+		return 0
+	if(ispath(antag_datum, /datum/antagonist/bandit))
 		if(story_bandit_conflicts())
 			return 0
 	else if(initial(antag_datum:storyteller_antag_flags) & STORYTELLER_ANTAG_VILLAIN && story_villain_conflicts(antag_datum))
@@ -1326,17 +1339,8 @@ SUBSYSTEM_DEF(gamemode)
 	return slot_count
 
 
-/datum/controller/subsystem/gamemode/proc/story_bandit_conflicts() // TA EDIT START
-	if(story_policy_type(TRUE) != /datum/storyteller/gamemode/guaranteed_antag) // TA EDIT
-		return FALSE // TA EDIT
-	var/datum/round_event_control/antagonist/solo/roundstart_event = current_roundstart_event
-	if(!roundstart_event)
-		return FALSE
-	if(istype(roundstart_event, /datum/round_event_control/antagonist/solo/lich))
-		return TRUE
-	if(istype(roundstart_event, /datum/round_event_control/antagonist/solo/vampires))
-		return TRUE
-	return FALSE // TA EDIT END
+/datum/controller/subsystem/gamemode/proc/story_bandit_conflicts()
+	return FALSE // TA EDIT
 
 /datum/controller/subsystem/gamemode/proc/story_villain_conflicts(antag_datum)
 	if(!ispath(antag_datum, /datum/antagonist))

--- a/code/datums/storytellers/presets.dm
+++ b/code/datums/storytellers/presets.dm
@@ -85,7 +85,7 @@
 /datum/storyteller/gamemode/guaranteed_antag
 	name = "High Intensity"
 	vote_desc = "Гарантированный крупный антагонист. Часть малых антагонистов остаётся."
-	desc = "Гарантированный раундстартовый крупный антагонист. До 9 изгоев (Wretches). До 2 гноллов. Карга (Hag) присутствует. Сноходец (Dreamwalker) может появиться."
+	desc = "Гарантированный раундстартовый крупный антагонист. До 7 изгоев (Wretches). До 2 гноллов. До 5 бандитов. Карга (Hag) присутствует. Сноходец (Dreamwalker) может появиться."
 	welcome_text = "Леденящий ужас плавно опускается на город..."
 	color_theme = "#a43c3c"
 	preset_pool = GAMEMODE_POOL_GUARANTEED
@@ -96,11 +96,11 @@
 	block_soft = FALSE
 	allow_dreamwalker = TRUE
 	preferred_gnoll_mode = GNOLL_SCALING_FLAT	// max 2
-	wretch_slot_cap = 9
+	wretch_slot_cap = 7 // TA EDIT
 /datum/storyteller/gamemode/guaranteed_antag/low_wretch
 	name = "Tempered Intensity"
 	vote_desc = "Гарантированный крупный антагонист случайного типа. Также присутствует несколько малых антагонистов."
-	desc = "Гарантированный раундстартовый крупный антагонист с более агрессивным масштабированием от онлайна. До 4 изгоев (Wretches). До 1 гнолла. Карга (Hag) присутствует. Сноходец (Dreamwalker) может появиться."
+	desc = "Гарантированный раундстартовый крупный антагонист с более агрессивным масштабированием от онлайна. До 4 изгоев (Wretches). До 1 гнолла. До 9 бандитов. Карга (Hag) присутствует. Сноходец (Dreamwalker) может появиться."
 	color_theme = "#7a1f1f"
 	hard_mult = 2
 	block_soft = FALSE

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -179,7 +179,7 @@
 
 		slots = 4 // TA EDIT START
 		if(player_count > 40)
-			if(storyteller_type == /datum/storyteller/gamemode/guaranteed_antag)
+			if(storyteller_type == /datum/storyteller/gamemode/guaranteed_antag || storyteller_type == /datum/storyteller/gamemode/guaranteed_antag/low_wretch)
 				slots += floor((player_count - 40) / 10)
 			else
 				slots += floor((player_count - 40) / 20)


### PR DESCRIPTION
## About The Pull Request

Теперь в хай интенсити от 60+ игроков бандитов всегда пять, не больше и не меньше, и они не мешают падать мажор антагам. Чуть уменьшил максимальное количество вретчей с 9 до 7, раз бандиты будут на постоянке.

## Testing Evidence

На локалке все норм

## Why It's Good For The Game

Все время жалуются что в хай интенсити нет мажоров. Проблема была в том, что часто падали бандиты вместо лича/вла/революции. 
Давным давно, бандиты всегда были гарантом и всем было нормально. В пятером они не смогут быть какой то страшной угрозой для города уж точно. В случае чего я опять поменяю цифры, пока это как эксперимент.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Бандиты теперь не мешают выпадению мажор антагов в хай интенсити
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
