### PR TITLE
Пофикшен баг с слишком маленьким тектом в слухах ерп нотесах флаворе.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -334,7 +334,7 @@
 //Returns a string with reserved characters and spaces before the first word and after the last word removed.
 /proc/trim(text, max_length)
 	if(max_length)
-		text = copytext(text, 1, max_length)
+		text = copytext_char(text, 1, max_length)//TA EDIT
 	return trim_left(trim_right(text))
 
 //Returns a string with the first element of the string capitalized.

--- a/code/modules/client/character_setup/act/character_creator/descriptors.dm
+++ b/code/modules/client/character_setup/act/character_creator/descriptors.dm
@@ -109,40 +109,40 @@
 				else
 					return CHARACTER_ACT_DATA_UPDATE
 
-			if(length(params["value"]) > max_length)
+			if(length_char(params["value"]) > max_length) //TA EDIT
 				to_chat(user, span_danger("Warning: [type_name] exceeds maximum length [max_length], it will be cut to size. Reload editors to see the final result in your Preferences Menu."))
 
 			var/value = trim(params["value"], PREVENT_CHARACTER_TRIM_LOSS(max_length)) || null
 			var/value_parsed = value ? parsemarkdown_basic(html_encode(value), hyperlink = TRUE) : null
 
 			var/prev_length
-			switch(type)
+			switch(type) //TA EDIT length_char <= length for non eng server
 				if("flavortext")
-					prev_length = length(flavortext)
+					prev_length = length_char(flavortext)
 					flavortext = value
 					flavortext_cached = value_parsed
 				if("ooc_notes")
-					prev_length = length(ooc_notes)
+					prev_length = length_char(ooc_notes)
 					ooc_notes = value
 					ooc_notes_cached = value_parsed
 				if("nsfwflavortext")
-					prev_length = length(nsfwflavortext)
+					prev_length = length_char(nsfwflavortext)
 					nsfwflavortext = value
 					nsfwflavortext_cached = value_parsed
 				if("erpprefs")
-					prev_length = length(erpprefs)
+					prev_length = length_char(erpprefs)
 					erpprefs = value
 					erpprefs_cached = value_parsed
 				if("rumour")
-					prev_length = length(rumour)
+					prev_length = length_char(rumour)
 					rumour = value
 					rumour_cached = value_parsed
 				if("noble_gossip")
-					prev_length = length(noble_gossip)
+					prev_length = length_char(noble_gossip)
 					noble_gossip = value
 					noble_gossip_cached = value_parsed
 
-			verbose_pref_log_change(user, "notice", "[type_name]", "[prev_length] characters", "[length(value)] characters")
+			verbose_pref_log_change(user, "notice", "[type_name]", "[prev_length] characters", "[length_char(value)] characters") //TA EDIT
 			log_game(replacetext(log, "%VALUE%", html_encode(value)))
 			return CHARACTER_ACT_DATA_UPDATE
 


### PR DESCRIPTION
## About The Pull Request
Ру буквы имели x2 вес, из-за этого флавор на русском был короче английского. Исправил 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Тестил на локалке.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
